### PR TITLE
Change JSON serialization in Curl wrapper to match JavaScript behavior

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -186,7 +186,7 @@ class BaseSession:
         else:
             raise TypeError("data must be dict, str, BytesIO or bytes")
         if json:
-            body = dumps(json).encode()
+            body = dumps(json, separators=(",", ":")).encode()
         if body:
             c.setopt(CurlOpt.POSTFIELDS, body)
             # necessary if body contains '\0'


### PR DESCRIPTION
This pull request addresses an issue with JSON serialization in the Curl wrapper module. Currently, the JSON.dumps() function used in the code produces serialized JSON output that differs from the format generated by JSON.stringify() in JavaScript. To align with the desired behavior of mimicking browser requests, this pull request introduces a modification to the serialization process.

The key change made is the addition of the `separators` parameter in the JSON.dumps() call. The separators=(",", ":") argument is used to remove whitespaces after commas and colons, ensuring a serialization format that closely resembles the output of vanilla browser JavaScript's JSON.stringify().

To illustrate the differences between the current Python output and the desired JavaScript-like output, consider the following example:

```javascript
JavaScript: JSON.stringify({"a": 0, "b": 1}) = {"a":0,"b":1}
```

```python
Python: json.dumps({"a": 0, "b": 1}) = {"a": 0, "b": 1}
```

By incorporating the separators option, the modified code now produces the following output:

```python
Python: json.dumps({"a": 0, "b": 1}, separators=(",", ":")) = {"a":0,"b":1}
```

This change ensures that the Curl wrapper's JSON serialization aligns more closely with the behavior of vanilla browser JavaScript.