### PR TITLE
Initialize BaseSession.proxies as an empty dict

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -149,7 +149,7 @@ class BaseSession:
         self.headers = Headers(headers)
         self.cookies = Cookies(cookies)
         self.auth = auth
-        self.proxies = proxies
+        self.proxies = proxies or {}
         self.params = params
         self.verify = verify
         self.timeout = timeout


### PR DESCRIPTION
This changes the behavior to match that of [requests.Session](https://github.com/psf/requests/blob/aa4cc78627bcf8ff87b73422ec06748d833c7a15/requests/sessions.py#L402-L405), and allows updating post-initialization.