### PR TITLE
Bugfix: cookies syncing between cookiejar and curl's cookie engine

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - master
+      - bugfix/*
       - feature/*
 jobs:
   bdist:

--- a/curl_cffi/const.py
+++ b/curl_cffi/const.py
@@ -520,9 +520,10 @@ class CurlECode(IntEnum):
 
 
 class CurlHttpVersion(IntEnum):
-   V1_0 = 1  # please use HTTP 1.0 in the request */
-   V1_1 = 2  # please use HTTP 1.1 in the request */
-   V2_0 = 3  # please use HTTP 2 in the request */
-   V2TLS = 4  # use version 2 for HTTPS, version 1.1 for HTTP */
-   V2_PRIOR_KNOWLEDGE = 5  # please use HTTP 2 without HTTP/1.1 Upgrade */
-   V3 = 30  # Makes use of explicit HTTP/3 without fallback.
+    NONE = 0
+    V1_0 = 1  # please use HTTP 1.0 in the request */
+    V1_1 = 2  # please use HTTP 1.1 in the request */
+    V2_0 = 3  # please use HTTP 2 in the request */
+    V2TLS = 4  # use version 2 for HTTPS, version 1.1 for HTTP */
+    V2_PRIOR_KNOWLEDGE = 5  # please use HTTP 2 without HTTP/1.1 Upgrade */
+    V3 = 30  # Makes use of explicit HTTP/3 without fallback.

--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -34,7 +34,7 @@ class CurlMorsel:
 
     @staticmethod
     def dump_bool(s):
-        return "TURE" if s else "FALSE"
+        return "TRUE" if s else "FALSE"
 
     @classmethod
     def from_curl_format(cls, set_cookie_line: bytes):
@@ -101,9 +101,7 @@ class CurlMorsel:
             value=self.value,
             port=None,
             port_specified=False,
-            domain=self.hostname
-            if self.hostname.startswith(".")
-            else "." + self.hostname,
+            domain=self.hostname,
             domain_specified=True,
             domain_initial_dot=bool(self.hostname.startswith(".")),
             path=self.path,

--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -92,17 +92,20 @@ class CurlMorsel:
         )
 
     def to_cookiejar_cookie(self) -> Cookie:
+        # the leading dot actually does not mean anything nowadays
+        # https://stackoverflow.com/a/20884869/1061155
+        # https://github.com/python/cpython/blob/d6555abfa7384b5a40435a11bdd2aa6bbf8f5cfc/Lib/http/cookiejar.py#L1535
         return Cookie(
             version=0,
             name=self.name,
             value=self.value,
             port=None,
             port_specified=False,
-            domain=self.hostname,
+            domain=self.hostname
+            if self.hostname.startswith(".")
+            else "." + self.hostname,
             domain_specified=True,
-            # the leading dot actually does not mean anything nowadays
-            # https://stackoverflow.com/a/20884869/1061155
-            domain_initial_dot=True,
+            domain_initial_dot=bool(self.hostname.startswith(".")),
             path=self.path,
             path_specified=bool(self.path),
             secure=self.secure,

--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -1,11 +1,14 @@
-# Adapted from https://github.com/encode/httpx/blob/master/httpx/_models.py,
+# Adapted from: https://github.com/encode/httpx/blob/master/httpx/_models.py,
 # which is licensed under the BSD License.
 # See https://github.com/encode/httpx/blob/master/LICENSE.md
 
 __all__ = ["Cookies"]
 
+import time
 import typing
-from http.cookiejar import Cookie, CookieJar
+import urllib.request
+from http.cookiejar import Cookie, CookieJar, eff_request_host  # type: ignore
+from dataclasses import dataclass
 
 from .errors import CookieConflict
 
@@ -14,9 +17,108 @@ CookieTypes = typing.Union[
 ]
 
 
+@dataclass
+class CurlMorsel:
+    name: str
+    value: str
+    hostname: str = ""
+    subdomains: bool = False
+    path: str = "/"
+    secure: bool = False
+    expires: int = 0
+    http_only: bool = False
+
+    @staticmethod
+    def parse_bool(s):
+        return s == "TRUE"
+
+    @staticmethod
+    def dump_bool(s):
+        return "TURE" if s else "FALSE"
+
+    @classmethod
+    def from_curl_format(cls, set_cookie_line: bytes):
+        (
+            hostname,
+            subdomains,
+            path,
+            secure,
+            expires,
+            name,
+            value,
+        ) = set_cookie_line.decode().split("\t")
+        if hostname and hostname[0] == "#":
+            http_only = True
+            # e.g. #HttpOnly_postman-echo.com
+            domain = hostname[10:]  # len("#HttpOnly_") == 10
+        else:
+            http_only = False
+            domain = hostname
+        return cls(
+            hostname=domain,
+            subdomains=cls.parse_bool(subdomains),
+            path=path,
+            secure=cls.parse_bool(secure),
+            expires=int(expires),
+            name=name,
+            value=value,
+            http_only=http_only,
+        )
+
+    def to_curl_format(self):
+        return "\t".join(
+            [
+                self.hostname,
+                self.dump_bool(self.subdomains),
+                self.path,
+                self.dump_bool(self.secure),
+                str(self.expires),
+                self.name,
+                self.value,
+            ]
+        )
+
+    @classmethod
+    def from_cookiejar_cookie(cls, cookie: Cookie):
+        return cls(
+            name=cookie.name,
+            value=cookie.value or "",
+            hostname=cookie.domain,
+            subdomains=cookie.domain_initial_dot,
+            path=cookie.path,
+            secure=cookie.secure,
+            expires=int(cookie.expires or 0),
+            http_only=False,
+        )
+
+    def to_cookiejar_cookie(self) -> Cookie:
+        return Cookie(
+            version=0,
+            name=self.name,
+            value=self.value,
+            port=None,
+            port_specified=False,
+            domain=self.hostname,
+            domain_specified=True,
+            # the leading dot actually does not mean anything nowadays
+            # https://stackoverflow.com/a/20884869/1061155
+            domain_initial_dot=True,
+            path=self.path,
+            path_specified=bool(self.path),
+            secure=self.secure,
+            # using if explicitly to make it clear.
+            expires=None if self.expires == 0 else self.expires,
+            discard=True if self.expires == 0 else False,
+            comment=None,
+            comment_url=None,
+            rest=dict(http_only=self.http_only),  # type: ignore
+            rfc2109=False,
+        )
+
+
 class Cookies(typing.MutableMapping[str, str]):
     """
-    Cookies, as a mutable mapping. A simple wrapper around `http.cookiejar.CookieJar`.
+    HTTP Cookies, as a mutable mapping.
     """
 
     def __init__(self, cookies: typing.Optional[CookieTypes] = None) -> None:
@@ -36,15 +138,34 @@ class Cookies(typing.MutableMapping[str, str]):
         else:
             self.jar = cookies
 
-    def set(
-        self,
-        name: str,
-        value: str,
-        domain: str = "",
-        path: str = "/",
-        expires: typing.Optional[int] = None,
-        secure: bool = False,
-    ) -> None:
+    def get_cookies_for_curl(self, request) -> typing.List[CurlMorsel]:
+        """the process is similar to `cookiejar.add_cookie_header`"""
+        urllib_request = self._CookieCompatRequest(request)
+        self.jar._cookies_lock.acquire()  # type: ignore
+        try:
+            self.jar._policy._now = self._now = int(time.time())  # type: ignore
+
+            cookies = self.jar._cookies_for_request(urllib_request)  # type: ignore
+            morsels = []
+            for cookie in cookies:
+                morsel = CurlMorsel.from_cookiejar_cookie(cookie)
+                if not morsel.hostname:
+                    _, erhn = eff_request_host(urllib_request)
+                    morsel.hostname = erhn
+                morsels.append(morsel)
+        finally:
+            self.jar._cookies_lock.release()  # type: ignore
+
+        self.jar.clear_expired_cookies()
+        return morsels
+
+    def update_cookies_from_curl(self, morsels: typing.List[CurlMorsel]):
+        for morsel in morsels:
+            cookie = morsel.to_cookiejar_cookie()
+            self.jar.set_cookie(cookie)
+        self.jar.clear_expired_cookies()
+
+    def set(self, name: str, value: str, domain: str = "", path: str = "/") -> None:
         """
         Set a cookie value by name. May optionally include domain and path.
         """
@@ -59,8 +180,8 @@ class Cookies(typing.MutableMapping[str, str]):
             "domain_initial_dot": domain.startswith("."),
             "path": path,
             "path_specified": bool(path),
-            "secure": secure,
-            "expires": expires,
+            "secure": False,
+            "expires": None,
             "discard": True,
             "comment": None,
             "comment_url": None,
@@ -158,14 +279,34 @@ class Cookies(typing.MutableMapping[str, str]):
         return (cookie.name for cookie in self.jar)
 
     def __bool__(self) -> bool:
-        return len(self.jar) > 0
+        for _ in self.jar:
+            return True
+        return False
 
     def __repr__(self) -> str:
         cookies_repr = ", ".join(
             [
-                f"<Cookie {cookie.name}={cookie.value} for {cookie.domain or 'all'} />"
+                f"<Cookie {cookie.name}={cookie.value} for {cookie.domain} />"
                 for cookie in self.jar
             ]
         )
 
         return f"<Cookies[{cookies_repr}]>"
+
+    class _CookieCompatRequest(urllib.request.Request):
+        """
+        Wraps a `Request` instance up in a compatibility interface suitable
+        for use with `CookieJar` operations.
+        """
+
+        def __init__(self, request) -> None:
+            super().__init__(
+                url=str(request.url),
+                headers=dict(request.headers),
+                method=request.method,
+            )
+            self.request = request
+
+        def add_unredirected_header(self, key: str, value: str) -> None:
+            super().add_unredirected_header(key, value)
+            self.request.headers[key] = value

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -32,8 +32,9 @@ class Response:
         redirect_count: how many redirects happened.
         redirect_url: the final redirected url.
         http_version: http version used.
+        history: history redirections, only headers are available.
     """
-    def __init__(self, curl: Curl, request: Optional[Request] = None):
+    def __init__(self, curl: Optional[Curl] = None, request: Optional[Request] = None):
         self.curl = curl
         self.request = request
         self.url = ""
@@ -49,6 +50,7 @@ class Response:
         self.redirect_count = 0
         self.redirect_url = ""
         self.http_version = 0
+        self.history = []
 
     @property
     def text(self) -> str:

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -241,6 +241,7 @@ class BaseSession:
         c.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
 
         for morsel in self.cookies.get_cookies_for_curl(req):
+            # print("Setting", morsel)
             curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
         if cookies:
             temp_cookies = Cookies(cookies)

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -241,7 +241,7 @@ class BaseSession:
         c.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
 
         for morsel in self.cookies.get_cookies_for_curl(req):
-            # print("Setting", morsel)
+            # print("Setting", morsel.to_curl_format())
             curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
         if cookies:
             temp_cookies = Cookies(cookies)
@@ -379,9 +379,12 @@ class BaseSession:
                 continue
             header_list.append(header_line)
         rsp.headers = Headers(header_list)
+        # print("Set-cookie", rsp.headers["set-cookie"])
         morsels = [
             CurlMorsel.from_curl_format(l) for l in c.getinfo(CurlInfo.COOKIELIST)
         ]
+        # for l in c.getinfo(CurlInfo.COOKIELIST):
+        #     print("Curl Cookies", l.decode())
 
         self.cookies.update_cookies_from_curl(morsels)
         rsp.cookies = self.cookies

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -4,7 +4,6 @@ import re
 import threading
 import warnings
 from enum import Enum
-from http.cookiejar import Cookie
 from functools import partialmethod
 from io import BytesIO
 from json import dumps
@@ -12,7 +11,7 @@ from typing import Callable, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 
 from .. import AsyncCurl, Curl, CurlError, CurlInfo, CurlOpt, CurlHttpVersion
-from .cookies import Cookies, CookieTypes
+from .cookies import Cookies, CookieTypes, CurlMorsel
 from .errors import RequestsError
 from .headers import Headers, HeaderTypes
 from .models import Request, Response
@@ -162,74 +161,6 @@ class BaseSession:
         self.debug = debug
         self.interface = interface
 
-    def _set_cookies(self, curl, cookies: Cookies):
-        curl.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
-        # Credits: @coletdjnz
-        # encoder = SimpleCookie()
-        for cookie in cookies.jar:
-            values = []
-            # _, value = encoder.value_encode(cookie.value)
-            # values.append(f"{cookie.name}={value}")
-            # Let curl decide how to encode cookies
-            values.append(f"{cookie.name}={cookie.value}")
-            if cookie.domain:
-                values.append(f"Domain={cookie.domain}")
-            if cookie.path:
-                values.append(f"Path={cookie.path}")
-            if cookie.secure:
-                values.append("Secure")
-            if cookie.expires:
-                values.append(f"Expires={cookie.expires}")
-            if cookie.version:
-                values.append(f"Version={cookie.version}")
-            cookie_line = "set-cookie: " + ("; ".join(values))
-            # print(cookie_line)
-            # https://curl.se/libcurl/c/CURLOPT_COOKIELIST.html
-            curl.setopt(CurlOpt.COOKIELIST, cookie_line.encode())
-
-    def _extract_cookies(self, curl) -> List[Cookie]:
-        cookie_lines = curl.getinfo(CurlInfo.COOKIELIST)
-        cookies = []
-        for cookie_line in cookie_lines:
-            (
-                hostname,
-                subdomains,
-                path,
-                secure,
-                expires,
-                name,
-                value,
-            ) = cookie_line.decode().split("\t")
-            if hostname and hostname[0] == "#":
-                http_only = True
-                # e.g. #HttpOnly_postman-echo.com
-                domain = hostname[10:]  # len("#HttpOnly_") == 10
-            else:
-                http_only = False
-                domain = hostname
-            cookies.append(
-                Cookie(
-                    version=0,
-                    name=name,
-                    value=value,
-                    port=None,
-                    port_specified=False,
-                    domain=domain,
-                    domain_specified=bool(domain),
-                    domain_initial_dot=(subdomains == "TRUE"),
-                    path=path,
-                    path_specified=bool(path),
-                    secure=(secure == "TRUE"),
-                    expires=int(expires),
-                    discard=False,
-                    comment=None,
-                    comment_url=None,
-                    rest=dict(http_only=http_only),  # type: ignore
-                    rfc2109=False,
-                )
-            )
-        return cookies
-
     def _set_curl_options(
         self,
         curl,
@@ -303,11 +234,18 @@ class BaseSession:
         # print("header lines", header_lines)
         c.setopt(CurlOpt.HTTPHEADER, [h.encode() for h in header_lines])
 
+        req = Request(url, h, method)
+
         # cookies
         c.setopt(CurlOpt.COOKIEFILE, b"")  # always enable the curl cookie engine first
-        co = Cookies(self.cookies)
-        co.update(cookies)
-        self._set_cookies(c, co)
+        c.setopt(CurlOpt.COOKIELIST, "ALL")  # remove all the old cookies first.
+
+        for morsel in self.cookies.get_cookies_for_curl(req):
+            curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
+        if cookies:
+            temp_cookies = Cookies(cookies)
+            for morsel in temp_cookies.get_cookies_for_curl(req):
+                curl.setopt(CurlOpt.COOKIELIST, morsel.to_curl_format())
 
         # files
         if files:
@@ -397,7 +335,6 @@ class BaseSession:
         for k, v in self.curl_options.items():
             c.setopt(k, v)
 
-        # import pdb; pdb.set_trace()
         if content_callback is None:
             buffer = BytesIO()
             c.setopt(CurlOpt.WRITEDATA, buffer)
@@ -415,7 +352,7 @@ class BaseSession:
         if interface:
             c.setopt(CurlOpt.INTERFACE, interface.encode())
 
-        return Request(url, h, method), buffer, header_buffer
+        return req, buffer, header_buffer
 
     def _parse_response(self, curl, buffer, header_buffer):
         c = curl
@@ -437,16 +374,15 @@ class BaseSession:
                 # read header from last response
                 rsp.reason = c.get_reason_phrase(header_line).decode()
                 # empty header list for new redirected response
-                header_list = [
-                    h for h in header_lines if h.lower().startswith(b"set-cookie")
-                ]
+                header_list = []
                 continue
             header_list.append(header_line)
         rsp.headers = Headers(header_list)
+        morsels = [
+            CurlMorsel.from_curl_format(l) for l in c.getinfo(CurlInfo.COOKIELIST)
+        ]
 
-        cookies = self._extract_cookies(c)
-        for cookie in cookies:
-            self.cookies.jar.set_cookie(cookie)
+        self.cookies.update_cookies_from_curl(morsels)
         rsp.cookies = self.cookies
         # print("Cookies after extraction", self.cookies)
 

--- a/preprocess/generate_consts.py
+++ b/preprocess/generate_consts.py
@@ -61,9 +61,10 @@ with open(CONST_FILE, "w") as f:
 
 
     f.write("class CurlHttpVersion(IntEnum):\n")
-    f.write("   V1_0 = 1  # please use HTTP 1.0 in the request */\n")
-    f.write("   V1_1 = 2  # please use HTTP 1.1 in the request */\n")
-    f.write("   V2_0 = 3  # please use HTTP 2 in the request */\n")
-    f.write("   V2TLS = 4  # use version 2 for HTTPS, version 1.1 for HTTP */\n")
-    f.write("   V2_PRIOR_KNOWLEDGE = 5  # please use HTTP 2 without HTTP/1.1 Upgrade */\n")
-    f.write("   V3 = 30  # Makes use of explicit HTTP/3 without fallback.\n")
+    f.write("    NONE = 0\n")
+    f.write("    V1_0 = 1  # please use HTTP 1.0 in the request */\n")
+    f.write("    V1_1 = 2  # please use HTTP 1.1 in the request */\n")
+    f.write("    V2_0 = 3  # please use HTTP 2 in the request */\n")
+    f.write("    V2TLS = 4  # use version 2 for HTTPS, version 1.1 for HTTP */\n")
+    f.write("    V2_PRIOR_KNOWLEDGE = 5  # please use HTTP 2 without HTTP/1.1 Upgrade */\n")
+    f.write("    V3 = 30  # Makes use of explicit HTTP/3 without fallback.\n")

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -93,6 +93,8 @@ async def app(scope, receive, send):
         await set_headers(scope, receive, send)
     elif scope["path"].startswith("/set_cookies"):
         await set_cookies(scope, receive, send)
+    elif scope["path"].startswith("/delete_cookies"):
+        await delete_cookies(scope, receive, send)
     elif scope["path"].startswith("/set_special_cookies"):
         await set_special_cookies(scope, receive, send)
     elif scope["path"].startswith("/redirect_301"):
@@ -297,6 +299,20 @@ async def set_cookies(scope, receive, send):
             "headers": [
                 [b"content-type", b"text/plain"],
                 [b"set-cookie", b"foo=bar"],
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+
+async def delete_cookies(scope, receive, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [
+                [b"content-type", b"text/plain"],
+                [b"set-cookie", b'foo=; Max-Age=0'],
             ],
         }
     )

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -237,7 +237,7 @@ def test_session_update_parms(server):
 
 
 def test_session_preset_cookies(server):
-    s = requests.Session(cookies={"foo": "bar"}, debug=True)
+    s = requests.Session(cookies={"foo": "bar"})
     # send requests with other cookies
     r = s.get(
         str(server.url.copy_with(path="/echo_cookies")), cookies={"hello": "world"}
@@ -257,6 +257,14 @@ def test_session_preset_cookies(server):
     )
     cookies = r.json()
     assert cookies["foo"] == "notbar"
+
+
+def test_delete_cookies(server):
+    s = requests.Session()
+    s.get(str(server.url.copy_with(path="/set_cookies")))
+    assert s.cookies["foo"] == "bar"
+    s.get(str(server.url.copy_with(path="/delete_cookies")))
+    assert not s.cookies.get("foo")
 
 
 def test_cookie_domains(server):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -237,7 +237,7 @@ def test_session_update_parms(server):
 
 
 def test_session_preset_cookies(server):
-    s = requests.Session(cookies={"foo": "bar"})
+    s = requests.Session(cookies={"foo": "bar"}, debug=True)
     # send requests with other cookies
     r = s.get(
         str(server.url.copy_with(path="/echo_cookies")), cookies={"hello": "world"}
@@ -247,8 +247,16 @@ def test_session_preset_cookies(server):
     assert cookies["foo"] == "bar"
     # new cookies should be added
     assert cookies["hello"] == "world"
+    # XXX request cookies will always be added to the entire session
     # request cookies should not be added to session cookiejar
-    assert s.cookies.get("hello") is None
+    # assert s.cookies.get("hello") is None
+
+    # but you can override
+    r = s.get(
+        str(server.url.copy_with(path="/echo_cookies")), cookies={"foo": "notbar"}
+    )
+    cookies = r.json()
+    assert cookies["foo"] == "notbar"
 
 
 def test_cookie_domains(server):


### PR DESCRIPTION
- Use a similar process with cookiejar.add_cookie_header to read cookies from cookiejar.
- Read cookies from curl using CurlInfo.COOKIELIST.
- Expire cookies explicitly.
- Add a dataclass for curl cookie pieces.