### PR TITLE
Match requests behavior with proxies dict, support "all" scheme

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -335,21 +335,27 @@ class BaseSession:
         # proxies
         if self.proxies:
             proxies = {**self.proxies, **(proxies or {})}
+
         if proxies:
-            if url.startswith("http://"):
-                if proxies["http"] is not None:
-                    c.setopt(CurlOpt.PROXY, proxies["http"])
-            elif url.startswith("https://"):
-                if proxies["https"] is not None:
-                    if proxies["https"].startswith("https://"):
-                        raise RequestsError(
-                            "You are using http proxy WRONG, the prefix should be 'http://' not 'https://',"
-                            "see: https://github.com/yifeikong/curl_cffi/issues/6"
-                        )
-                    c.setopt(CurlOpt.PROXY, proxies["https"])
-                    # for http proxy, need to tell curl to enable tunneling
-                    if not proxies["https"].startswith("socks"):
-                        c.setopt(CurlOpt.HTTPPROXYTUNNEL, 1)
+            parts = urlparse(url)
+            proxy = proxies.get(parts.scheme, proxies.get("all"))
+            if parts.hostname:
+                proxy = proxies.get(
+                    f"{parts.scheme}://{parts.hostname}",
+                    proxies.get(f"all://{parts.hostname}"),
+                ) or proxy
+
+            if proxy is not None:
+                if parts.scheme == "https" and proxy.startswith("https://"):
+                    raise RequestsError(
+                        "You are using http proxy WRONG, the prefix should be 'http://' not 'https://',"
+                        "see: https://github.com/yifeikong/curl_cffi/issues/6"
+                    )
+
+                c.setopt(CurlOpt.PROXY, proxy)
+                # for http proxy, need to tell curl to enable tunneling
+                if not proxy.startswith("socks"):
+                    c.setopt(CurlOpt.HTTPPROXYTUNNEL, 1)
 
         # verify
         if verify is False or not self.verify and verify is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "trio-typing==0.7.0",
     "trustme==0.9.0",
     "uvicorn==0.18.3",
+    "proxy.py==2.4.3",
 ]
 
 

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -8,6 +8,7 @@ from asyncio import sleep
 from collections import defaultdict
 from urllib.parse import parse_qs
 
+import proxy
 import pytest
 import trustme
 from cryptography.hazmat.backends import default_backend
@@ -589,3 +590,10 @@ def https_server(cert_pem_file, cert_private_key_file):
     )
     server = TestServer(config=config)
     yield from serve_in_thread(server)
+
+
+@pytest.fixture(scope="session")
+def proxy_server(request):
+    ps = proxy.Proxy(port=8002, plugins=['proxy.plugin.ManInTheMiddlePlugin'])
+    request.addfinalizer(ps.__exit__)
+    return ps.__enter__()

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -427,6 +427,39 @@ def test_session_with_headers(server):
     assert r.status_code == 200
 
 
+# https://github.com/yifeikong/curl_cffi/pull/171
+def test_session_with_hostname_proxies(server, proxy_server):
+    proxies = {
+        f'all://{server.url.host}': f'http://{proxy_server.flags.hostname}:{proxy_server.flags.port}'
+    }
+    s = requests.Session(proxies=proxies)
+    url = str(server.url.copy_with(path="/echo_headers"))
+    r = s.get(url)
+    assert r.text == 'Hello from man in the middle'
+
+
+# https://github.com/yifeikong/curl_cffi/pull/171
+def test_session_with_http_proxies(server, proxy_server):
+    proxies = {
+        'http': f'http://{proxy_server.flags.hostname}:{proxy_server.flags.port}'
+    }
+    s = requests.Session(proxies=proxies)
+    url = str(server.url.copy_with(path="/echo_headers"))
+    r = s.get(url)
+    assert r.text == 'Hello from man in the middle'
+
+
+# https://github.com/yifeikong/curl_cffi/pull/171
+def test_session_with_all_proxies(server, proxy_server):
+    proxies = {
+        'all': f'http://{proxy_server.flags.hostname}:{proxy_server.flags.port}'
+    }
+    s = requests.Session(proxies=proxies)
+    url = str(server.url.copy_with(path="/echo_headers"))
+    r = s.get(url)
+    assert r.text == 'Hello from man in the middle'
+
+
 def test_stream_iter_content(server):
     with requests.Session() as s:
         url = str(server.url.copy_with(path="/stream"))


### PR DESCRIPTION
Previously, curl_cffi would crash if given a dict with no proxy set for a given scheme. Now, it will use the value per scheme if set, otherwise fallback to all (if set). Also allows proxies to be set per scheme+hostname, similar to requests.

Reference: [psf/requests: requests/utils.py#L833-L856](https://github.com/psf/requests/blob/769bc3ae5cc8cb42242e4505b310dd10889cb54c/src/requests/utils.py#L833-L856)