### PR TITLE
Add Firefox curl-impersonate

### DIFF
--- a/curl_cffi/__init__.py
+++ b/curl_cffi/__init__.py
@@ -1,5 +1,7 @@
 __all__ = [
     "Curl",
+    "CurlChrome",
+    "CurlFirefox",
     "CurlInfo",
     "CurlOpt",
     "CurlMOpt",
@@ -7,15 +9,20 @@ __all__ = [
     "CurlHttpVersion",
     "CurlError",
     "AsyncCurl",
+    "AsyncCurlChrome",
+    "AsyncCurlFirefox",
     "ffi",
     "lib",
+    "ffi_ff",
+    "lib_ff",
 ]
 
-# This line includes _wrapper.so into the wheel
-from ._wrapper import ffi, lib
+# This line includes _wrapper_{chrome,ff}.so into the wheel
+from ._wrapper_chrome import ffi, lib
+from ._wrapper_ff import ffi as ffi_ff, lib as lib_ff
 
 from .const import CurlInfo, CurlMOpt, CurlOpt, CurlECode, CurlHttpVersion
-from .curl import Curl, CurlError
-from .aio import AsyncCurl
+from .curl import Curl, CurlChrome, CurlFirefox, CurlError
+from .aio import AsyncCurl, AsyncCurlChrome, AsyncCurlFirefox
 
-from .__version__ import __title__, __version__, __description__, __curl_version__
+from .__version__ import __title__, __version__, __description__, __curl_version__, __curl_chrome_version__, __curl_firefox_version__

--- a/curl_cffi/__version__.py
+++ b/curl_cffi/__version__.py
@@ -1,6 +1,6 @@
 # New in version 3.8.
 # from importlib import metadata
-from .curl import Curl
+from .curl import Curl, CurlFirefox
 
 
 __title__ = "curl_cffi"
@@ -9,3 +9,5 @@ __title__ = "curl_cffi"
 __description__ = "libcurl ffi bindings for Python, with impersonation support"
 __version__ = "0.5.10"
 __curl_version__ = Curl().version().decode()
+__curl_chrome_version__ = __curl_version__
+__curl_firefox_version__ = CurlFirefox().version().decode()

--- a/curl_cffi/build.py
+++ b/curl_cffi/build.py
@@ -3,42 +3,43 @@ import platform
 
 from cffi import FFI
 
-ffibuilder = FFI()
 # arch = "%s-%s" % (os.uname().sysname, os.uname().machine)
 uname = platform.uname()
 
 
-ffibuilder.set_source(
-    "curl_cffi._wrapper",
-    """
-        #include "shim.h"
-    """,
-    libraries=["curl-impersonate-chrome"] if uname.system != "Windows" else ["libcurl"],
-    library_dirs=[
-        "/Users/runner/work/_temp/install/lib"
-        if uname.system == "Darwin" and uname.machine == "x86_64"
-        else "./lib"
-        if uname.system == "Windows"
-        else "/usr/local/lib"  # Linux and macOS arm64
-    ],
-    source_extension=".c",
-    include_dirs=[
-        os.path.join(os.path.dirname(__file__), "include"),
-        os.path.join(os.path.dirname(__file__), "ffi"),
-    ],
-    sources=[
-        os.path.join(os.path.dirname(__file__), "ffi/shim.c"),
-    ],
-    extra_compile_args=(
-        ["-Wno-implicit-function-declaration"] if uname.system == "Darwin" else []
-    ),
-    # extra_link_args=["-Wl,-rpath,$ORIGIN/../libcurl/" + arch],
-)
+for distro in ["chrome", "ff"]:
+    ffibuilder = FFI()
+    ffibuilder.set_source(
+        "curl_cffi._wrapper_"+distro,
+        """
+            #include "shim.h"
+        """,
+        libraries=["curl-impersonate-"+distro] if uname.system != "Windows" else ["libcurl"],
+        library_dirs=[
+            "/Users/runner/work/_temp/install/lib"
+            if uname.system == "Darwin" and uname.machine == "x86_64"
+            else "./lib"
+            if uname.system == "Windows"
+            else "/usr/local/lib"  # Linux and macOS arm64
+        ],
+        source_extension=".c",
+        include_dirs=[
+            os.path.join(os.path.dirname(__file__), "include"),
+            os.path.join(os.path.dirname(__file__), "ffi"),
+        ],
+        sources=[
+            os.path.join(os.path.dirname(__file__), "ffi/shim.c"),
+        ],
+        extra_compile_args=(
+            ["-Wno-implicit-function-declaration"] if uname.system == "Darwin" else []
+        ),
+        # extra_link_args=["-Wl,-rpath,$ORIGIN/../libcurl/" + arch],
+    )
 
-with open(os.path.join(os.path.dirname(__file__), "ffi/cdef.c")) as f:
-    cdef_content = f.read()
-    ffibuilder.cdef(cdef_content)
+    with open(os.path.join(os.path.dirname(__file__), "ffi/cdef.c")) as f:
+        cdef_content = f.read()
+        ffibuilder.cdef(cdef_content)
 
 
-if __name__ == "__main__":
-    ffibuilder.compile(verbose=False)
+    if __name__ == "__main__":
+        ffibuilder.compile(verbose=False)

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -21,6 +21,7 @@ from functools import partial
 from io import BytesIO
 from typing import Callable, Dict, Optional, Tuple, Union
 
+from ..curl import Curl
 from ..const import CurlHttpVersion
 from .cookies import Cookies, CookieTypes
 from .models import Request, Response
@@ -56,6 +57,7 @@ def request(
     http_version: Optional[CurlHttpVersion] = None,
     debug: bool = False,
     interface: Optional[str] = None,
+    curl: Optional[Curl] = None
 ) -> Response:
     """Send an http request.
 
@@ -88,7 +90,7 @@ def request(
     Returns:
         A [Response](/api/curl_cffi.requests#curl_cffi.requests.Response) object.
     """
-    with Session(thread=thread, curl_options=curl_options, debug=debug) as s:
+    with Session(thread=thread, curl_options=curl_options, debug=debug, curl=curl) as s:
         return s.request(
             method=method,
             url=url,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -13,7 +13,7 @@ from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 from concurrent.futures import ThreadPoolExecutor
 
 
-from .. import AsyncCurl, Curl, CurlError, CurlInfo, CurlOpt, CurlHttpVersion
+from .. import AsyncCurl, Curl, CurlFirefox, CurlError, CurlInfo, CurlOpt, CurlHttpVersion
 from ..curl import CURL_WRITEFUNC_ERROR
 from .cookies import Cookies, CookieTypes, CurlMorsel
 from .errors import RequestsError
@@ -43,6 +43,13 @@ class BrowserType(str, Enum):
     chrome99_android = "chrome99_android"
     safari15_3 = "safari15_3"
     safari15_5 = "safari15_5"
+    ff91esr = "ff91esr"
+    ff95 = "ff95"
+    ff98 = "ff98"
+    f100 = "ff100"
+    ff102 = "ff102"
+    ff109 = "ff109"
+    ff117 = "ff117"
 
     @classmethod
     def has(cls, item):
@@ -367,6 +374,9 @@ class BaseSession:
         if impersonate:
             if not BrowserType.has(impersonate):
                 raise RequestsError(f"impersonate {impersonate} is not supported")
+            if impersonate.startswith("ff"):
+                if not isinstance(c, CurlFirefox):
+                    raise RequestsError(f"CurlFirefox required to impersonate {impersonate}, got {type(c)}")
             c.impersonate(impersonate, default_headers=default_headers)
 
         # http_version, after impersonate, which will change this to http2


### PR DESCRIPTION
Adds the Firefox build of curl-impersonate as a separate cffi module, built into and distributed with the `curl_cffi` package. This change parameterizes all references to `ffi` and `lib` to use ones loaded from either chrome or ff. No external modules needed.

Firefox's libnss requires installing the libnss3 package on the host to get the system certificates, which are bundled into a shared object. An alternate is to use libnsspem to support PEM certificates like Chrome, but this library is not currently built into the main nss distribution. Perhaps curl-impersonate could be extended someday to link against it by default, or `curl_cffi` could vendor it using auditwheel.

I will keep it as a draft for now to gather feedback.

Resolves #59 
Resolves #177 