### PR TITLE
Explicit import dependency of `_wrapper`

### DIFF
--- a/curl_cffi/__init__.py
+++ b/curl_cffi/__init__.py
@@ -11,8 +11,9 @@ __all__ = [
     "lib",
 ]
 
+import _cffi_backend  # noqa: F401  # required by _wrapper
 # This line includes _wrapper.so into the wheel
-from ._wrapper import ffi, lib
+from ._wrapper import ffi, lib  # type: ignore
 
 from .const import CurlInfo, CurlMOpt, CurlOpt, CurlECode, CurlHttpVersion
 from .curl import Curl, CurlError


### PR DESCRIPTION
Refs:
- https://github.com/yifeikong/curl_cffi/issues/48
- https://github.com/yifeikong/curl_cffi/issues/29
- https://github.com/yifeikong/curl_cffi/issues/5
- https://github.com/Nuitka/Nuitka/issues/2505


(Related docs will be updated in next PR)