### PR TITLE
Drop `cacert.pem` in favor of `certifi`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist/
 wheelhouse/
 curl.egg-info/
 curl_cffi.egg-info/
-curl_cffi/cacert.pem
 # curl_cffi/const.py
 curl-*/
 *.tar.xz

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include curl_cffi/cacert.pem
 include curl_cffi/_wrapper.*
 include curl_cffi/ffi/*
 include curl_cffi/include/curl/*

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := bash
 VERSION := 0.5.4
 CURL_VERSION := curl-7.84.0
 
-.preprocessed: curl_cffi/include/curl/curl.h curl_cffi/cacert.pem .so_downloaded
+.preprocessed: curl_cffi/include/curl/curl.h .so_downloaded
 	touch .preprocessed
 
 curl_cffi/const.py: curl_cffi/include
@@ -26,10 +26,6 @@ curl_cffi/include/curl/curl.h: curl-impersonate-$(VERSION)/chrome/patches
 	autoreconf -fi
 	mkdir -p ../curl_cffi/include/curl
 	cp -R include/curl/* ../curl_cffi/include/curl/
-
-curl_cffi/cacert.pem:
-	# https://curl.se/docs/caextract.html
-	curl https://curl.se/ca/cacert.pem -o curl_cffi/cacert.pem
 
 .so_downloaded:
 	python preprocess/download_so.py
@@ -55,7 +51,7 @@ build: .preprocessed
 
 clean:
 	rm -rf build/ dist/ curl_cffi.egg-info/ $(CURL_VERSION)/ curl-impersonate-$(VERSION)/
-	rm -rf curl_cffi/*.o curl_cffi/*.so curl_cffi/_wrapper.c curl_cffi/cacert.pem
+	rm -rf curl_cffi/*.o curl_cffi/*.so curl_cffi/_wrapper.c
 	rm -rf .preprocessed .so_downloaded $(CURL_VERSION).tar.xz curl-impersonate-$(VERSION).tar.gz
 	rm -rf curl_cffi/include/
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -8,11 +8,11 @@ import tls_client
 import httpx
 import curl_cffi
 import curl_cffi.requests
-import uvloop
 import queue
 import threading
 from io import BytesIO
 
+# import uvloop
 # uvloop.install()
 
 results = []
@@ -25,7 +25,6 @@ class FakePycurlSession:
         buffer = BytesIO()
         self.c.setopt(pycurl.URL, url)
         self.c.setopt(pycurl.WRITEDATA, buffer)
-        # self.c.setopt(pycurl.CAINFO, certifi.where())
         self.c.perform()
 
     def __del__(self):
@@ -40,7 +39,6 @@ class FakeCurlCffiSession:
         buffer = BytesIO()
         self.c.setopt(curl_cffi.CurlOpt.URL, url)
         self.c.setopt(curl_cffi.CurlOpt.WRITEDATA, buffer)
-        # self.c.setopt(pycurl.CAINFO, certifi.where())
         self.c.perform()
 
     def __del__(self):

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -1,17 +1,14 @@
-import os
 import re
 import warnings
 from http.cookies import SimpleCookie
 from typing import Any, List, Tuple, Union
 
+import certifi
+
 from ._wrapper import ffi, lib  # type: ignore
 from .const import CurlHttpVersion, CurlInfo, CurlOpt
 
-try:
-    import certifi
-    DEFAULT_CACERT = certifi.where()
-except ImportError:
-    DEFAULT_CACERT = os.path.join(os.path.dirname(__file__), "cacert.pem")
+DEFAULT_CACERT = certifi.where()
 
 
 class CurlError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ description = "libcurl ffi bindings for Python, with impersonation support"
 license = { file = "LICENSE" }
 dependencies = [
     "cffi >=1.12.0",
+    "certifi",
     "typing_extensions; python_version < '3.8'",
 ]
 readme = "README.md"


### PR DESCRIPTION
Refs:
- https://github.com/yifeikong/curl_cffi/issues/115
- https://github.com/yifeikong/curl_cffi/issues/104
- https://github.com/yifeikong/curl_cffi/issues/71
- https://github.com/Nuitka/Nuitka/issues/2505
- Also, PyInstaller did not able to collect it.
