### PR TITLE
Improve WebSocket close implementation

### DIFF
--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "Request",
     "Response",
     "WebSocket",
+    "WebSocketError",
     "WsCloseCode",
 ]
 
@@ -30,7 +31,7 @@ from .models import Request, Response
 from .errors import RequestsError
 from .headers import Headers, HeaderTypes
 from .session import AsyncSession, BrowserType, Session
-from .websockets import WebSocket, WsCloseCode
+from .websockets import WebSocket, WebSocketError, WsCloseCode
 
 # ThreadType = Literal["eventlet", "gevent", None]
 

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     "Session",
     "AsyncSession",
     "BrowserType",
+    "CurlWsFlag",
     "request",
     "head",
     "get",
@@ -16,19 +17,20 @@ __all__ = [
     "Request",
     "Response",
     "WebSocket",
+    "WsCloseCode",
 ]
 
 from functools import partial
 from io import BytesIO
 from typing import Callable, Dict, Optional, Tuple, Union
 
-from ..const import CurlHttpVersion
+from ..const import CurlHttpVersion, CurlWsFlag
 from .cookies import Cookies, CookieTypes
 from .models import Request, Response
 from .errors import RequestsError
 from .headers import Headers, HeaderTypes
 from .session import AsyncSession, BrowserType, Session
-from .websockets import WebSocket
+from .websockets import WebSocket, WsCloseCode
 
 # ThreadType = Literal["eventlet", "gevent", None]
 

--- a/curl_cffi/requests/websockets.py
+++ b/curl_cffi/requests/websockets.py
@@ -1,5 +1,8 @@
-from typing import Callable, Optional, Tuple
 import asyncio
+import struct
+from enum import IntEnum
+from typing import Callable, Optional, Tuple
+
 from curl_cffi.const import CurlECode, CurlWsFlag
 from curl_cffi.curl import CurlError
 
@@ -7,7 +10,28 @@ from curl_cffi.curl import CurlError
 ON_MESSAGE_T = Callable[["WebSocket", bytes], None]
 ON_ERROR_T = Callable[["WebSocket", CurlError], None]
 ON_OPEN_T = Callable[["WebSocket"], None]
-ON_CLOSE_T = Callable[["WebSocket"], None]
+ON_CLOSE_T = Callable[["WebSocket", int, str], None]
+
+
+class WsCloseCode(IntEnum):
+    OK = 1000
+    GOING_AWAY = 1001
+    PROTOCOL_ERROR = 1002
+    UNSUPPORTED_DATA = 1003
+    UNKNOWN = 1005
+    ABNORMAL_CLOSURE = 1006
+    INVALID_DATA = 1007
+    POLICY_VIOLATION = 1008
+    MESSAGE_TOO_BIG = 1009
+    MANDATORY_EXTENSION = 1010
+    INTERNAL_ERROR = 1011
+    SERVICE_RESTART = 1012
+    TRY_AGAIN_LATER = 1013
+    BAD_GATEWAY = 1014
+
+
+class WebSocketError(CurlError):
+    pass
 
 
 class WebSocket:
@@ -69,23 +93,44 @@ class WebSocket:
         """
         if self.on_open:
             self.on_open(self)
-        try:
-            # Keep reading the messages and invoke callbacks
-            while self.keep_running:
-                try:
-                    msg, flags = self.recv()
-                    if self.on_message:
-                        self.on_message(self, msg)
-                    if flags & CurlWsFlag.CLOSE:
-                        self.keep_running = False
-                except CurlError as e:
-                    if self.on_error:
-                        self.on_error(self, e)
-        finally:
-            if self.on_close:
-                self.on_close(self)
 
-    def close(self, msg: bytes = b""):
+        # Keep reading the messages and invoke callbacks
+        while self.keep_running:
+            try:
+                msg, flags = self.recv()
+                if self.on_message:
+                    self.on_message(self, msg)
+                if flags & CurlWsFlag.CLOSE:
+                    self.keep_running = False
+                    # Unpack close code and reason
+                    if len(msg) < 2:
+                        code = WsCloseCode.UNKNOWN
+                        reason = ""
+                    else:
+                        try:
+                            code = struct.unpack_from("!H", msg)[0]
+                            reason = msg[2:].decode()
+                        except UnicodeDecodeError:
+                            raise WebSocketError("Invalid close message", WsCloseCode.INVALID_DATA)
+                        except Exception:
+                            raise WebSocketError("Invalid close frame", WsCloseCode.PROTOCOL_ERROR)
+                        else:
+                            if code < 3000 and (code not in WsCloseCode or code == 1005):
+                                raise WebSocketError("Invalid close code", WsCloseCode.PROTOCOL_ERROR)
+                    if self.on_close:
+                        self.on_close(self, code, reason)
+            except WebSocketError as e:
+                # Follow the spec to close the connection
+                # TODO: Consider adding setting to autoclose connection on error-free close
+                self.close(e.code)
+                if self.on_error:
+                    self.on_error(self, e)
+            except CurlError as e:
+                if self.on_error:
+                    self.on_error(self, e)
+
+    def close(self, code: int = WsCloseCode.OK, message: bytes = b""):
+        msg = struct.pack("!H", code) + message
         # FIXME how to reset, or can a curl handle connect to two websockets?
         self.send(msg, CurlWsFlag.CLOSE)
         self.keep_running = False
@@ -97,13 +142,13 @@ class WebSocket:
             self._loop = asyncio.get_running_loop()
         return self._loop
 
-    async def arecv(self):
+    async def arecv(self) -> Tuple[bytes, int]:
         return await self.loop.run_in_executor(None, self.recv)
 
     async def asend(self, payload: bytes, flags: CurlWsFlag = CurlWsFlag.BINARY):
         return await self.loop.run_in_executor(None, self.send, payload, flags)
 
-    async def aclose(self):
-        await self.loop.run_in_executor(None, self.close)
+    async def aclose(self, code: int = WsCloseCode.OK, message: bytes = b""):
+        await self.loop.run_in_executor(None, self.close, code, message)
         self.curl.reset()
         self.session.push_curl(self.curl)


### PR DESCRIPTION
- Allow passing close code/message directly to close()
- Fix aclose() not accepting parameters
- Implement close code/message parsing and provide to on_close handler
   + Might make sense to put this in recv() and return a class instance containing parsed data instead of raw bytes, similar to aiohttp
- Add close code enum and expose WebSocket enums
- Close socket on protocol error (as per spec)
   + Should probably check for other protocol errors in the future and raise accordingly
   + Clients are supposed to reply with a close message whenever they receive a close frame no matter what (as per spec), so consider doing that as well (though not entirely necessary, can be left up to user)
