### PR TITLE
Improve proxy support

### DIFF
--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 __all__ = [
     "Session",
     "AsyncSession",

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = [
     "Session",
     "AsyncSession",
@@ -30,7 +32,7 @@ from .cookies import Cookies, CookieTypes
 from .models import Request, Response
 from .errors import RequestsError
 from .headers import Headers, HeaderTypes
-from .session import AsyncSession, BrowserType, Session
+from .session import AsyncSession, BrowserType, Session, ProxySpec
 from .websockets import WebSocket, WebSocketError, WsCloseCode
 
 # ThreadType = Literal["eventlet", "gevent", None]
@@ -49,7 +51,9 @@ def request(
     timeout: Union[float, Tuple[float, float]] = 30,
     allow_redirects: bool = True,
     max_redirects: int = -1,
-    proxies: Optional[dict] = None,
+    proxies: Optional[ProxySpec] = None,
+    proxy: Optional[str] = None,
+    proxy_auth: Optional[Tuple[str, str]] = None,
     verify: Optional[bool] = None,
     referer: Optional[str] = None,
     accept_encoding: Optional[str] = "gzip, deflate, br",
@@ -78,6 +82,8 @@ def request(
         allow_redirects: whether to allow redirection.
         max_redirects: max redirect counts, default unlimited(-1).
         proxies: dict of proxies to use, format: {"http": proxy_url, "https": proxy_url}.
+        proxy: proxy to use, format: "http://proxy_url". Cannot be used with the above parameter.
+        proxy_auth: HTTP basic auth for proxy, a tuple of (username, password).
         verify: whether to verify https certs.
         referer: shortcut for setting referer header.
         accept_encoding: shortcut for setting accept-encoding header.
@@ -108,6 +114,8 @@ def request(
             allow_redirects=allow_redirects,
             max_redirects=max_redirects,
             proxies=proxies,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
             verify=verify,
             referer=referer,
             accept_encoding=accept_encoding,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -377,9 +377,11 @@ class BaseSession:
 
             if proxy is not None:
                 if parts.scheme == "https" and proxy.startswith("https://"):
-                    raise RequestsError(
-                        "You are using http proxy WRONG, the prefix should be 'http://' not 'https://',"
-                        "see: https://github.com/yifeikong/curl_cffi/issues/6"
+                    warnings.warn(
+                        "You may be using http proxy WRONG, the prefix should be 'http://' not 'https://',"
+                        "see: https://github.com/yifeikong/curl_cffi/issues/6",
+                        RuntimeWarning,
+                        stacklevel=2,
                     )
 
                 c.setopt(CurlOpt.PROXY, proxy)

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import partialmethod
 from io import BytesIO
 from json import dumps
-from typing import Callable, Dict, List, Any, Optional, Tuple, TypedDict, Union, cast
+from typing import Callable, Dict, List, Any, Optional, Tuple, Union, cast, TYPE_CHECKING
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urlparse
 from concurrent.futures import ThreadPoolExecutor
 
@@ -30,6 +30,19 @@ try:
     import eventlet.tpool
 except ImportError:
     pass
+
+if TYPE_CHECKING:
+    from typing_extensions import TypedDict
+
+    class ProxySpec(TypedDict, total=False):
+        all: str
+        http: str
+        https: str
+        ws: str
+        wss: str
+
+else:
+    ProxySpec = Dict[str, str]
 
 
 class BrowserType(str, Enum):
@@ -63,14 +76,6 @@ class BrowserSpec:
     """A more structured way of selecting browsers"""
 
     # TODO
-
-
-class ProxySpec(TypedDict, total=False):
-    all: str
-    http: str
-    https: str
-    ws: str
-    wss: str
 
 
 def _update_url_params(url: str, params: Dict) -> str:


### PR DESCRIPTION
Fulfills one of the requests in #202.
- Adds a new `proxy` parameter as an alternative to `proxies`. This just applies the proxy to all URL schemes.
- Implements the `proxy_auth` parameter as a better way to authenticate with proxies that require HTTP Basic authentication.
- Changes https-to-https proxy exception to a warning, fixes #180.


~~Unrelated, but I noticed these lines:~~ https://github.com/yifeikong/curl_cffi/blob/aefc2475de5b235e242dc6b9438ece3ed1416549/curl_cffi/requests/session.py#L352-L356 ~~seem to prevent HTTPS over HTTPS proxies from being used. Is this intentional?~~