### PR TITLE
Bugfix UnicodeDecodeError exception raising when debug=True

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -38,7 +38,7 @@ def debug_function(curl, type: int, data, size, clientp) -> int:
     if type in (CURLINFO_SSL_DATA_IN, CURLINFO_SSL_DATA_OUT):
         print("SSL OUT", text)
     elif type in (CURLINFO_DATA_IN, CURLINFO_DATA_OUT):
-        print(text.decode())
+        print(text.decode("utf-8", "replace"))
     else:
         print(text.decode(), end="")
     return 0


### PR DESCRIPTION
If set debug=True:
```python3
requests.AsyncSession(impersonate="chrome", debug=True)
```
debugging information is printed. But exceptions of this kind often appear among the text:
```python3
Exception ignored from cffi callback <function debug_function at 0x7f0f245a80e0>:
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.11/site-packages/curl_cffi/curl.py", line 40, in debug_function
    print(text.decode())
          ^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb3 in position 1: invalid start byte
```
```python3
Exception ignored from cffi callback <function debug_function at 0x7f0f245a80e0>:
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.11/site-packages/curl_cffi/curl.py", line 40, in debug_function
    print(text.decode())
          ^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd5 in position 8: invalid continuation byte
```