### PR TITLE
Suppress Pending Task Messages During Shutdown

### DIFF
--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -145,6 +145,12 @@ class AsyncCurl:
         """Close and cleanup running timers, readers, writers and handles."""
         # Close force timeout checker
         self._checker.cancel()
+        # Wait for the force timeout checker to finish
+        try:
+            self.loop.run_until_complete(self._checker)
+        except asyncio.CancelledError:
+            # This is expected since we just cancelled the task
+            pass
         # Close all pending futures
         for curl, future in self._curl2future.items():
             lib.curl_multi_remove_handle(self._curlm, curl._curl)

--- a/curl_cffi/aio.py
+++ b/curl_cffi/aio.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import warnings
+from contextlib import suppress
 from typing import Any
 from weakref import WeakSet, WeakKeyDictionary
 
@@ -146,11 +147,8 @@ class AsyncCurl:
         # Close force timeout checker
         self._checker.cancel()
         # Wait for the force timeout checker to finish
-        try:
+        with suppress(asyncio.CancelledError):
             self.loop.run_until_complete(self._checker)
-        except asyncio.CancelledError:
-            # This is expected since we just cancelled the task
-            pass
         # Close all pending futures
         for curl, future in self._curl2future.items():
             lib.curl_multi_remove_handle(self._curlm, curl._curl)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "uvicorn==0.18.3",
     "websockets==11.0.3",
     "ruff==0.1.14",
+    "nest_asyncio==1.6.0",
 ]
 build = [
     "cibuildwheel",
@@ -64,6 +65,7 @@ test = [
     "websockets==11.0.3",
     "python-multipart==0.0.6",
     "fastapi==0.100.0",
+    "nest_asyncio==1.6.0",
 ]
 
 

--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -1,11 +1,13 @@
 import asyncio
 import base64
 import json
-
+import nest_asyncio
 import pytest
 
 from curl_cffi.requests import AsyncSession, RequestsError
 from curl_cffi.requests.errors import SessionClosed
+
+nest_asyncio.apply()
 
 
 async def test_get(server):


### PR DESCRIPTION
### Reason:

Sometimes there are messages like this one:
```python3
Task was destroyed but it is pending!
task: <Task cancelling name='Task-2' coro=<AsyncCurl._force_timeout() done, defined at .venv/lib/python3.12/site-packages/curl_cffi/aio.py:164> wait_for=<Future cancelled>>
```

### Description:

This PR addresses the issue of warning messages being logged when the AsyncCurl object is closed. Specifically, it resolves the "Task was destroyed but it is pending!" warnings that occur when the _checker task is cancelled.

### Changes Made:
Modified close method: added a try/except block to catch and ignore asyncio.CancelledError when cancelling the _checker task. This prevents the warning message from being logged.

```python3
def close(self):
    # Cancel the force timeout checker
    self._checker.cancel()
    # Wait for the force timeout checker to finish
    try:
        self.loop.run_until_complete(self._checker)
    except asyncio.CancelledError:
        # This is expected since we just cancelled the task
        pass
    # ... rest of the cleanup code ...
```
These changes ensure that the _checker task is cancelled gracefully, and the cancellation is confirmed before continuing with the cleanup process. This should eliminate the warning messages related to pending tasks during object closure.
