### PR TITLE
Improve Response repr: Display HTTP status code.

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -194,3 +194,9 @@ class Response:
     async def aclose(self):
         if self.stream_task:
             await self.stream_task  # type: ignore
+
+            
+    # It prints the status code of the response instead of
+    # the object's memory location.
+    def __repr__(self)->str:
+        return f"<Response [{self.status_code}]>"


### PR DESCRIPTION
## Pull Request

### Changes Made
Enhanced the `__repr__` method for `Response` objects to display the HTTP status code in the format "<Response [status_code]>". This provides a more meaningful representation when printing the object.

```python
def __repr__(self)->str:
    return f"<Response [{self.status_code}]>"
```
