### PR TITLE
BaseSession._parse_response(): optimize regex pattern and method performance

### DIFF
--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 else:
     ProxySpec = Dict[str, str]
 
+CHARSET_RE = re.compile(r"charset=([\w-]+)")
 ThreadType = Literal["eventlet", "gevent"]
 
 class BrowserType(str, Enum):
@@ -546,8 +547,8 @@ class BaseSession:
         # print("Cookies after extraction", self.cookies)
 
         content_type = rsp.headers.get("Content-Type", default="")
-        m = re.search(r"charset=([\w-]+)", content_type)
-        charset = m.group(1) if m else "utf-8"
+        charset_match = CHARSET_RE.search(content_type)
+        charset = charset_match.group(1) if charset_match else "utf-8"
 
         rsp.charset = charset
         rsp.encoding = charset  # TODO use chardet

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -122,6 +122,8 @@ async def app(scope, receive, send):
         await hello_world_json(scope, receive, send)
     elif scope["path"].startswith("/incomplete_read"):
         await incomplete_read(scope, receive, send)
+    elif scope["path"].startswith("/gbk"):
+        await hello_world_gbk(scope, receive, send)
     elif scope["path"].startswith("http://"):
         await http_proxy(scope, receive, send)
     elif scope["method"] == "CONNECT":
@@ -150,6 +152,17 @@ async def hello_world_json(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b'{"Hello": "world!"}'})
+
+
+async def hello_world_gbk(scope, receive, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain; charset=gbk"]],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Hello, world!"})
 
 
 async def http_proxy(scope, receive, send):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -114,6 +114,11 @@ def test_headers(server):
     assert headers["Foo"][0] == "bar"
 
 
+def test_charset_parse(server):
+    r = requests.get( str(server.url.copy_with(path="/gbk")))
+    assert r.charset == "gbk"
+
+
 def test_content_type_header_with_json(server):
     # FIXME: this actually does not work, because the test server uvicorn will merge
     # Content-Type headers, so it always works even if there is duplicate headers.


### PR DESCRIPTION
The regex pattern used to extract the charset from the Content-Type header is now compiled once outside the method and reused, reducing the overhead of pattern compilation on each call.
