### PR TITLE
Include libcurl-impersonate.so when building wheel from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include include/curl/*
 include scripts/build.py
 include Makefile
 include libs.json
+include curl_cffi/*.so

--- a/libs.json
+++ b/libs.json
@@ -39,7 +39,7 @@
         "system": "Linux",
         "machine": "x86_64",
         "pointer_size": 64,
-        "libdir": "~/.local/lib",
+        "libdir": "./curl_cffi",
         "sysname": "linux-gnu",
         "so_name": "libcurl-impersonate-chrome.so",
         "so_arch": "x86_64"
@@ -48,7 +48,7 @@
         "system": "Linux",
         "machine": "aarch64",
         "pointer_size": 64,
-        "libdir": "~/.local/lib",
+        "libdir": "./curl_cffi",
         "sysname": "linux-gnu",
         "so_name": "libcurl-impersonate-chrome.so",
         "so_arch": "aarch64"
@@ -57,7 +57,7 @@
         "system": "Linux",
         "machine": "armv6l",
         "pointer_size": 32,
-        "libdir": "~/.local/lib",
+        "libdir": "./curl_cffi",
         "sysname": "linux-gnueabihf",
         "so_name": "libcurl-impersonate-chrome.so",
         "so_arch": "arm"
@@ -66,7 +66,7 @@
         "system": "Linux",
         "machine": "armv7l",
         "pointer_size": 32,
-        "libdir": "~/.local/lib",
+        "libdir": "./curl_cffi",
         "sysname": "linux-gnueabihf",
         "so_name": "libcurl-impersonate-chrome.so",
         "so_arch": "arm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,10 +100,14 @@ test-skip = "pp*"
 
 
 [tool.cibuildwheel.linux]
+# install zip for usage below
+before-all = "yum install -y zip && make preprocess"
 # configure cibuildwheel to build native archs ('auto'), and some emulated ones
 archs = ["auto", "aarch64"]
-# no need to repair if the .so file is already included
-repair-wheel-command = ""
+environment = { LD_LIBRARY_PATH="$PWD/curl_cffi" }
+environment-pass = ["LD_LIBRARY_PATH"]
+# remove the extra libcurl-impersonate.so copied into the wheel
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel} && zip -d /tmp/cibuildwheel/repaired_wheel/*.whl curl_cffi/libcurl-impersonate-chrome.so"
 
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ test-skip = "pp*"
 # configure cibuildwheel to build native archs ('auto'), and some emulated ones
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
-environment = { LD_LIBRARY_PATH="$HOME/.local/lib" }
+environment = { LD_LIBRARY_PATH="$PWD/curl_cffi" }
 environment-pass = ["LD_LIBRARY_PATH"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,11 +99,11 @@ test-extras = ["test"]
 test-skip = "pp*"
 
 
-# configure cibuildwheel to build native archs ('auto'), and some emulated ones
 [tool.cibuildwheel.linux]
+# configure cibuildwheel to build native archs ('auto'), and some emulated ones
 archs = ["auto", "aarch64"]
-environment = { LD_LIBRARY_PATH="$PWD/curl_cffi" }
-environment-pass = ["LD_LIBRARY_PATH"]
+# no need to repair if the .so file is already included
+repair-wheel-command = ""
 
 
 [tool.cibuildwheel.macos]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -78,6 +78,7 @@ ffibuilder.set_source(
     extra_compile_args=(
         ["-Wno-implicit-function-declaration"] if system == "Darwin" else []
     ),
+    extra_link_args=["-Wl,-rpath=$ORIGIN"] if system == "Linux" else [],
 )
 
 with open(root_dir / "ffi/cdef.c") as f:


### PR DESCRIPTION
However, the `libcurl-impersonate.so` will be duplicated in the bdist.