### PR TITLE
Add `base_url` to `BaseSession`

### DIFF
--- a/tests/unittest/test_async_session.py
+++ b/tests/unittest/test_async_session.py
@@ -64,6 +64,13 @@ async def test_options(server):
         assert r.status_code == 200
 
 
+async def test_base_url(server):
+    async with AsyncSession(base_url=str(server.url)) as s:
+        r = await s.get("/echo_params", params={"foo": "bar"})
+        assert r.status_code == 200
+        assert r.content == b'{"params": {"foo": ["bar"]}}'
+
+
 async def test_params(server):
     async with AsyncSession() as s:
         r = await s.get(str(server.url.copy_with(path="/echo_params")), params={"foo": "bar"})

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -263,9 +263,31 @@ def test_session_options(server):
 
 
 def test_session_base_url(server):
-    s = requests.Session(base_url=str(server.url))
-    r = s.get("/echo_params", params={"foo": "bar"})
-    assert r.content == b'{"params": {"foo": ["bar"]}}'
+    s = requests.Session(base_url=str(server.url.copy_with(path="/a/b", params={"foo": "bar"})))
+
+    # target path is empty
+    r = s.get("")
+    assert r.url == s.base_url
+
+    # target path only has params
+    r = s.get("", params={"hello": "world"})
+    assert r.url == str(server.url.copy_with(path="/a/b", params={"hello": "world"}))
+
+    # target path is a relative path without starting /
+    r = s.get("x")
+    assert r.url == str(server.url.copy_with(path="/a/x"))
+    r = s.get("x", params={"hello": "world"})
+    assert r.url == str(server.url.copy_with(path="/a/x", params={"hello": "world"}))
+
+    # target path is a relative path with starting /
+    r = s.get("/x")
+    assert r.url == str(server.url.copy_with(path="/x"))
+    r = s.get("/x", params={"hello": "world"})
+    assert r.url == str(server.url.copy_with(path="/x", params={"hello": "world"}))
+
+    # target path is an absolute url
+    r = s.get(str(server.url.copy_with(path="/x/y")))
+    assert r.url == str(server.url.copy_with(path="/x/y"))
 
 
 def test_session_update_parms(server):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -262,6 +262,12 @@ def test_session_options(server):
     assert r.status_code == 200
 
 
+def test_session_base_url(server):
+    s = requests.Session(base_url=str(server.url))
+    r = s.get("/echo_params", params={"foo": "bar"})
+    assert r.content == b'{"params": {"foo": ["bar"]}}'
+
+
 def test_session_update_parms(server):
     s = requests.Session(params={"old": "day"})
     r = s.get(str(server.url.copy_with(path="/echo_params")), params={"foo": "bar"})


### PR DESCRIPTION
Resolves #181

----

Here're some example usages of this new parameter:
```python
>>> requests.Session(base_url="http://www.example.com/").get("/test").url
'http://www.example.com/test'
>>> requests.Session(base_url="http://www.example.com/a/b").get("c").url
'http://www.example.com/a/c'
>>> requests.Session(base_url="http://www.example.com/a/b/").get("c").url
'http://www.example.com/a/b/c'
>>> requests.Session(base_url="http://www.example.com/a/b?a=b").get("").url
'http://www.example.com/a/b?a=b'
>>> requests.Session(base_url="http://www.example.com/a/b?a=b").get("?c=d").url
'http://www.example.com/a/b?c=d'
```

Please note that it might not work the same as the current version of `httpx`, which is mentioned in the original issue.
For example, this is what `httpx` does:
```python
>>> httpx.Client(base_url="http://www.example.com/a/b").get("c").url # different
URL('http://www.example.com/a/b/c')
>>> httpx.Client(base_url="http://www.example.com/a/b/").get("c").url # same
URL('http://www.example.com/a/b/c')
```
I didn't follow `httpx`'s style. In my point of view, following RFC 3986 as what `urljoin` of `urllib.parse` does make more sense to me, since it works exactly the same as how the browser treats relative paths.
