### PR TITLE
Introduce `default_encoding` parameter to [set|autodetect] the encoding if the charset is missing from the headers

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -19,8 +19,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: |
@@ -31,15 +31,15 @@ jobs:
     name: Build sdist wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           make preprocess
           pipx run build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3  # https://github.com/actions/upload-artifact/issues/478
         with:
           path: ./dist/*.tar.gz
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: |
@@ -52,14 +52,14 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-12, macos-14, windows-2019]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
@@ -67,15 +67,14 @@ jobs:
       - if: runner.os == 'macOS'
         run: |
           brew install make automake libtool
-          which pipx || brew install pipx && pipx ensurepath
 
       - name: Build and test wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
 
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3  # https://github.com/actions/upload-artifact/issues/478
         with:
           path: ./wheelhouse/*.whl
 
@@ -83,20 +82,20 @@ jobs:
     needs: [bdist, sdist]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v3  # https://github.com/actions/upload-artifact/issues/478
       if: startsWith(github.ref, 'refs/tags/')
       with:
         name: artifact
         path: dist
 
-    - uses: pypa/gh-action-pypi-publish@v1.5.0
+    - uses: pypa/gh-action-pypi-publish@v1.8.14
       if: startsWith(github.ref, 'refs/tags/')
       with:
         password: ${{ secrets.PYPI_TOKEN }}
 
     - name: Upload release files
       if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           ./dist/*.whl

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -58,6 +58,7 @@ def request(
     impersonate: Optional[Union[str, BrowserType]] = None,
     thread: Optional[ThreadType] = None,
     default_headers: Optional[bool] = None,
+    default_encoding: Union[str, Callable[[bytes], str]] = "utf-8",
     curl_options: Optional[dict] = None,
     http_version: Optional[CurlHttpVersion] = None,
     debug: bool = False,
@@ -90,6 +91,8 @@ def request(
         impersonate: which browser version to impersonate.
         thread: work with other thread implementations. choices: eventlet, gevent.
         default_headers: whether to set default browser headers.
+        default_encoding: encoding for decoding response content if charset is not found in headers. 
+                Defaults to "utf-8". Can be set to a callable for automatic detection.
         curl_options: extra curl options to use.
         http_version: limiting http version, http2 will be tries by default.
         debug: print extra curl debug info.
@@ -122,6 +125,7 @@ def request(
             content_callback=content_callback,
             impersonate=impersonate,
             default_headers=default_headers,
+            default_encoding=default_encoding,
             http_version=http_version,
             interface=interface,
             multipart=multipart,

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -1,13 +1,17 @@
 import queue
+import re
 import warnings
 from concurrent.futures import Future
+from functools import cached_property
 from json import loads
-from typing import Any, Awaitable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 
 from .. import Curl
 from .cookies import Cookies
 from .errors import RequestsError
 from .headers import Headers
+
+CHARSET_RE = re.compile(r"charset=([\w-]+)")
 
 
 def clear_queue(q: queue.Queue):
@@ -41,6 +45,8 @@ class Response:
         elapsed: how many seconds the request cost.
         encoding: http body encoding.
         charset: alias for encoding.
+        charset_encoding: encoding specified by the Content-Type header.
+        default_encoding: user-defined encoding used for decoding content if charset is not found in headers.
         redirect_count: how many redirects happened.
         redirect_url: the final redirected url.
         http_version: http version used.
@@ -58,8 +64,7 @@ class Response:
         self.headers = Headers()
         self.cookies = Cookies()
         self.elapsed = 0.0
-        self.encoding = "utf-8"
-        self.charset = self.encoding
+        self.default_encoding: Union[str, Callable[[bytes], str]] = "utf-8"
         self.redirect_count = 0
         self.redirect_url = ""
         self.http_version = 0
@@ -70,15 +75,61 @@ class Response:
         self.astream_task: Optional[Awaitable] = None
         self.quit_now = None
 
-    def _decode(self, content: bytes) -> str:
-        try:
-            return content.decode(self.charset, errors="replace")
-        except (UnicodeDecodeError, LookupError):
-            return content.decode("utf-8-sig")
+    @property
+    def charset(self) -> str:
+        """Alias for encoding."""
+        return self.encoding
+
+    @property
+    def encoding(self) -> str:
+        """
+        Determines the encoding to decode byte content into text.
+
+        The method follows a specific priority to decide the encoding:
+        1. If `.encoding` has been explicitly set, it is used.
+        2. The encoding specified by the `charset` parameter in the `Content-Type` header.
+        3. The encoding specified by the `default_encoding` attribute. This can either be
+           a string (e.g., "utf-8") or a callable for charset autodetection.
+        """
+        if not hasattr(self, "_encoding"):
+            encoding = self.charset_encoding
+            if encoding is None:
+                if isinstance(self.default_encoding, str):
+                    encoding = self.default_encoding
+                elif callable(self.default_encoding):
+                    encoding = self.default_encoding(self.content)
+            self._encoding = encoding or "utf-8"
+        return self._encoding
+
+    @encoding.setter
+    def encoding(self, value: str) -> None:
+        if hasattr(self, "_text"):
+            raise ValueError("Cannot set encoding after text has been accessed")
+        self._encoding = value
+
+    @property
+    def charset_encoding(self) -> Optional[str]:
+        """Return the encoding, as specified by the Content-Type header."""
+        content_type = self.headers.get("Content-Type")
+        if content_type:
+            charset_match = CHARSET_RE.search(content_type)
+            return charset_match.group(1) if charset_match else None
+        return None
 
     @property
     def text(self) -> str:
-        return self._decode(self.content)
+        if not hasattr(self, "_text"):
+            if not self.content:
+                self._text = ""
+            else:
+                self._text = self._decode(self.content)
+        return self._text
+
+    def _decode(self, content: bytes) -> str:
+        try:
+            return content.decode(self.encoding, errors="replace")
+        except (UnicodeDecodeError, LookupError):
+            return content.decode("utf-8-sig")
 
     def raise_for_status(self):
         """Raise an error if status code is not in [200, 400)"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "libcurl ffi bindings for Python, with impersonation support."
 license = { file = "LICENSE" }
 dependencies = [
     "cffi>=1.12.0",
-    "certifi",
+    "certifi>=2024.2.2",
 ]
 readme = "README.md"
 requires-python = ">=3.8"
@@ -27,6 +27,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "autoflake==1.4",
+    "charset_normalizer>=3.3.2,<4",
     "coverage==6.4.1",
     "cryptography==38.0.3",
     "flake8==6.0.0",
@@ -50,6 +51,7 @@ build = [
     "wheel",
 ]
 test = [
+    "charset_normalizer>=3.3.2,<4",
     "cryptography==38.0.3",
     "httpx==0.23.1",
     "types-certifi==2021.10.8.2",

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -124,6 +124,8 @@ async def app(scope, receive, send):
         await incomplete_read(scope, receive, send)
     elif scope["path"].startswith("/gbk"):
         await hello_world_gbk(scope, receive, send)
+    elif scope["path"].startswith("/windows1251"):
+        await hello_world_windows1251(scope, receive, send)
     elif scope["path"].startswith("http://"):
         await http_proxy(scope, receive, send)
     elif scope["method"] == "CONNECT":
@@ -163,6 +165,22 @@ async def hello_world_gbk(scope, receive, send):
         }
     )
     await send({"type": "http.response.body", "body": b"Hello, world!"})
+
+
+async def hello_world_windows1251(scope, receive, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        }
+    )
+    await send(
+        {
+            "type": "http.response.body",
+            "body": "Bсеки човек има право на образование.".encode("cp1251"),
+        }
+    )
 
 
 async def http_proxy(scope, receive, send):

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -4,6 +4,7 @@ import time
 from io import BytesIO
 
 import pytest
+from charset_normalizer import detect
 
 from curl_cffi import CurlOpt, requests
 from curl_cffi.const import CurlECode, CurlInfo
@@ -109,7 +110,22 @@ def test_headers(server):
 
 def test_charset_parse(server):
     r = requests.get(str(server.url.copy_with(path="/gbk")))
-    assert r.charset == "gbk"
+    assert r.encoding == "gbk"
+
+
+def test_charset_default_encoding(server):
+    r = requests.get(
+        str(server.url.copy_with(path="/windows1251")), default_encoding="windows-1251"
+    )
+    assert r.encoding == "windows-1251"
+
+
+def test_charset_default_encoding_autodetect(server):
+    def autodetect(content):
+        return detect(content).get("encoding")
+
+    r = requests.get(str(server.url.copy_with(path="/windows1251")), default_encoding=autodetect)
+    assert r.encoding == "windows-1251"
 
 
 def test_content_type_header_with_json(server):


### PR DESCRIPTION
## PR summary:

1. Added `default_encoding` parameter
2. Updated github actions
_____


### Using the default encoding

When requests are made to a site without explicit character set information from the server, but the encoding is known, it's advisable to explicitly set the default encoding.

```python
from curl_cffi import requests

resp = requests.get(..., default_encoding="shift-jis")
print(response.encoding)  # Shows charset given in the Content-Type charset, or else "shift-jis".
print(response.text)  # The text decoded with the Content-Type charset, or using "shift-jis".
```

**Using character set auto-detection**

When the server doesn't provide character set information reliably, and the encoding is unknown, enabling auto-detection allows for a best-effort guess when converting bytes to text. To activate auto-detection, set the default_encoding parameter to a function that takes input bytes and returns the appropriate character set for decoding.

Let's take a look at autodetection using [`charset-normalizer`](https://github.com/Ousret/charset_normalizer)

```python
from curl_cffi import requests
from charset_normalizer import detect

def autodetect(content):
    return detect(content).get("encoding")

# Using a session with character-set autodetection enabled.
s = requests.Session(default_encoding=autodetect)
resp = s.get(...)
print(resp.encoding)  # Shows charset given in the Content-Type charset, or else autodetect() result.
print(resp.text)  # The text decoded with the Content-Type charset, or encoding, detected via autodetect.
```