### PR TITLE
fix(curl): Set PROXY_CAINFO curlopt with CAINFO, fixes HTTPS proxies

### DIFF
--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -272,6 +272,8 @@ class Curl:
         if not self._is_cert_set:
             ret = self.setopt(CurlOpt.CAINFO, self._cacert)
             self._check_error(ret, "set cacert")
+            ret = self.setopt(CurlOpt.PROXY_CAINFO, self._cacert)
+            self._check_error(ret, "set proxy cacert")
 
     def perform(self, clear_headers: bool = True) -> None:
         """Wrapper for ``curl_easy_perform``, performs a curl request.


### PR DESCRIPTION
Fixes HTTPS proxies by giving Curl a Cert-Authority bundle to lookup and verify SSL certs with.
Tested with NordVPN (HTTPS-only proxies) on GB servers.

Before with a NordVPN HTTPS proxy:

```
RequestsError: Failed to perform, curl: (60) SSL certificate problem: unable to
get local issuer certificate. See https://curl.se/libcurl/c/libcurl-errors.html
first for more details.
```

With this change it successfullly downloads multiple requests sequentially on the same thread and in multiple threads concurrently.

See discussion from: https://github.com/yifeikong/curl_cffi/issues/6#issuecomment-2028518677

(Note: Tests seem to fail because of upstream CI build failures, not because of code changes).