### PR TITLE
fix: add missing parameters from session request

### DIFF
--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -63,8 +63,10 @@ def request(
     http_version: Optional[CurlHttpVersion] = None,
     debug: bool = False,
     interface: Optional[str] = None,
-    multipart: Optional[CurlMime] = None,
     cert: Optional[Union[str, Tuple[str, str]]] = None,
+    stream: bool = False,
+    max_recv_speed: int = 0,    
+    multipart: Optional[CurlMime] = None,
 ) -> Response:
     """Send an http request.
 
@@ -128,8 +130,10 @@ def request(
             default_encoding=default_encoding,
             http_version=http_version,
             interface=interface,
-            multipart=multipart,
             cert=cert,
+            stream=stream,
+            max_recv_speed=max_recv_speed,
+            multipart=multipart,
         )
 
 


### PR DESCRIPTION
I found that the function signatures of `requests.request` and `session.request` are not consistent. Apart from the additional parameters passed to the Session constructor, the ‘stream’ and ‘max_recv_speed’ parameters are missing. I’m not sure if this is intentional or an oversight. If it is intentional, please close this PR.