### PR TITLE
Add server ip address to response object

### DIFF
--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -44,6 +44,7 @@ class Response:
         elapsed: how many seconds the request cost.
         encoding: http body encoding.
         charset: alias for encoding.
+        ip: primary ip of the server.
         charset_encoding: encoding specified by the Content-Type header.
         default_encoding: encoding for decoding response content if charset is not found in
                 headers. Defaults to "utf-8". Can be set to a callable for automatic detection.
@@ -68,6 +69,7 @@ class Response:
         self.redirect_count = 0
         self.redirect_url = ""
         self.http_version = 0
+        self.ip: str = ""
         self.history: List[Dict[str, Any]] = []
         self.infos: Dict[str, Any] = {}
         self.queue: Optional[queue.Queue] = None

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -599,7 +599,10 @@ class BaseSession:
         self.cookies.update_cookies_from_curl(morsels)
         rsp.cookies = self.cookies
         # print("Cookies after extraction", self.cookies)
-
+        rsp.ip = cast(bytes, c.getinfo(CurlInfo.PRIMARY_IP)).decode()
+        rsp.certs = []
+        for i in range(c.getinfo(CurlInfo.NUM_CERTS)):
+            rsp.certs.append(c.getinfo(CurlInfo.CERTINFO, i))
         rsp.default_encoding = default_encoding
         rsp.elapsed = cast(float, c.getinfo(CurlInfo.TOTAL_TIME))
         rsp.redirect_count = cast(int, c.getinfo(CurlInfo.REDIRECT_COUNT))

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -595,7 +595,6 @@ class BaseSession:
         morsels = [CurlMorsel.from_curl_format(c) for c in c.getinfo(CurlInfo.COOKIELIST)]
         # for l in c.getinfo(CurlInfo.COOKIELIST):
         #     print("Curl Cookies", l.decode())
-
         self.cookies.update_cookies_from_curl(morsels)
         rsp.cookies = self.cookies
         # print("Cookies after extraction", self.cookies)

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -600,9 +600,6 @@ class BaseSession:
         rsp.cookies = self.cookies
         # print("Cookies after extraction", self.cookies)
         rsp.ip = cast(bytes, c.getinfo(CurlInfo.PRIMARY_IP)).decode()
-        rsp.certs = []
-        for i in range(c.getinfo(CurlInfo.NUM_CERTS)):
-            rsp.certs.append(c.getinfo(CurlInfo.CERTINFO, i))
         rsp.default_encoding = default_encoding
         rsp.elapsed = cast(float, c.getinfo(CurlInfo.TOTAL_TIME))
         rsp.redirect_count = cast(int, c.getinfo(CurlInfo.REDIRECT_COUNT))


### PR DESCRIPTION
Ideally the response object should include the established server ip. Curl already offers that which is a better alternative to opening an entirely new socket connection to resolve that data.

```python
import curl_cffi.requests as requests

resp = requests.get("https://example.com")
print(resp.ip)
```