### PR TITLE
feat: add better type hints for impersonate and session

### DIFF
--- a/curl_cffi/__init__.py
+++ b/curl_cffi/__init__.py
@@ -21,5 +21,13 @@ from .__version__ import __curl_version__, __description__, __title__, __version
 # This line includes _wrapper.so into the wheel
 from ._wrapper import ffi, lib
 from .aio import AsyncCurl
-from .const import CurlECode, CurlHttpVersion, CurlInfo, CurlMOpt, CurlOpt, CurlWsFlag, CurlSslVersion
+from .const import (
+    CurlECode,
+    CurlHttpVersion,
+    CurlInfo,
+    CurlMOpt,
+    CurlOpt,
+    CurlSslVersion,
+    CurlWsFlag,
+)
 from .curl import Curl, CurlError, CurlMime

--- a/curl_cffi/_asyncio_selector.py
+++ b/curl_cffi/_asyncio_selector.py
@@ -321,15 +321,15 @@ class AddThreadSelectorEventLoop(asyncio.AbstractEventLoop):
         self._selector.close()
         self._real_loop.close()
 
-    def add_reader(
+    def add_reader(  # type: ignore
         self,
         fd: "_FileDescriptorLike",
         callback: Callable[..., None],
-        *args: Any,  # type: ignore
+        *args: Any,
     ) -> None:
         return self._selector.add_reader(fd, callback, *args)
 
-    def add_writer(
+    def add_writer(  # type: ignore
         self,
         fd: "_FileDescriptorLike",
         callback: Callable[..., None],

--- a/curl_cffi/curl.py
+++ b/curl_cffi/curl.py
@@ -163,7 +163,7 @@ class Curl:
             10000: "char*",
             20000: "void*",
             30000: "int64_t*",  # offset type
-            40000: "void*",     # blob type
+            40000: "void*",  # blob type
         }
         # print("option", option, "value", value)
 
@@ -195,7 +195,7 @@ class Curl:
             if option == CurlOpt.POSTFIELDS:
                 self._body_handle = c_value
         else:
-            raise NotImplementedError("Option unsupported: %s" % option)
+            raise NotImplementedError(f"Option unsupported: {option}")
 
         if option == CurlOpt.HTTPHEADER:
             for header in value:

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -26,7 +26,6 @@ from functools import partial
 from io import BytesIO
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
-
 from ..const import CurlHttpVersion, CurlWsFlag
 from ..curl import CurlMime
 from .cookies import Cookies, CookieTypes

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -20,6 +20,9 @@ __all__ = [
     "WebSocketError",
     "WsCloseCode",
     "ExtraFingerprints",
+    "CookieTypes",
+    "HeaderTypes",
+    "ProxySpec",
 ]
 
 from functools import partial

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -2,6 +2,7 @@ __all__ = [
     "Session",
     "AsyncSession",
     "BrowserType",
+    "BrowserTypeLiteral",
     "CurlWsFlag",
     "request",
     "head",
@@ -34,9 +35,9 @@ from ..curl import CurlMime
 from .cookies import Cookies, CookieTypes
 from .errors import RequestsError
 from .headers import Headers, HeaderTypes
-from .impersonate import ExtraFingerprints, ExtraFpDict
+from .impersonate import BrowserType, BrowserTypeLiteral, ExtraFingerprints, ExtraFpDict
 from .models import Request, Response
-from .session import AsyncSession, BrowserType, ProxySpec, Session, ThreadType
+from .session import AsyncSession, ProxySpec, Session, ThreadType
 from .websockets import WebSocket, WebSocketError, WsCloseCode
 
 
@@ -60,7 +61,7 @@ def request(
     referer: Optional[str] = None,
     accept_encoding: Optional[str] = "gzip, deflate, br, zstd",
     content_callback: Optional[Callable] = None,
-    impersonate: Optional[BrowserType] = None,
+    impersonate: Optional[BrowserTypeLiteral] = None,
     ja3: Optional[str] = None,
     akamai: Optional[str] = None,
     extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,

--- a/curl_cffi/requests/__init__.py
+++ b/curl_cffi/requests/__init__.py
@@ -58,7 +58,7 @@ def request(
     referer: Optional[str] = None,
     accept_encoding: Optional[str] = "gzip, deflate, br, zstd",
     content_callback: Optional[Callable] = None,
-    impersonate: Optional[Union[str, BrowserType]] = None,
+    impersonate: Optional[BrowserType] = None,
     ja3: Optional[str] = None,
     akamai: Optional[str] = None,
     extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,

--- a/curl_cffi/requests/cookies.py
+++ b/curl_cffi/requests/cookies.py
@@ -185,9 +185,7 @@ class Cookies(MutableMapping[str, str]):
             self.jar.set_cookie(cookie)
         self.jar.clear_expired_cookies()
 
-    def set(
-        self, name: str, value: str, domain: str = "", path: str = "/", secure=False
-    ) -> None:
+    def set(self, name: str, value: str, domain: str = "", path: str = "/", secure=False) -> None:
         """
         Set a cookie value by name. May optionally include domain and path.
         """
@@ -268,18 +266,14 @@ class Cookies(MutableMapping[str, str]):
             return default
         return value
 
-    def get_dict(
-        self, domain: Optional[str] = None, path: Optional[str] = None
-    ) -> dict:
+    def get_dict(self, domain: Optional[str] = None, path: Optional[str] = None) -> dict:
         """
         Cookies with the same name on different domains may overwrite each other,
         do NOT use this function as a method of serialization.
         """
         ret = {}
         for cookie in self.jar:
-            if (domain is None or cookie.name == domain) and (
-                path is None or cookie.path == path
-            ):
+            if (domain is None or cookie.name == domain) and (path is None or cookie.path == path):
                 ret[cookie.name] = cookie.value
         return ret
 
@@ -350,10 +344,7 @@ class Cookies(MutableMapping[str, str]):
 
     def __repr__(self) -> str:
         cookies_repr = ", ".join(
-            [
-                f"<Cookie {cookie.name}={cookie.value} for {cookie.domain} />"
-                for cookie in self.jar
-            ]
+            [f"<Cookie {cookie.name}={cookie.value} for {cookie.domain} />" for cookie in self.jar]
         )
 
         return f"<Cookies[{cookies_repr}]>"

--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -1,12 +1,11 @@
-from dataclasses import dataclass
-from typing import List, Literal, Optional, TypedDict, TypeAlias, Tuple, Union, Callable
 import warnings
+from dataclasses import dataclass
+from typing import Callable, List, Literal, Optional, Tuple, TypedDict, Union
 
-from curl_cffi.requests import HeaderTypes, CookieTypes, ProxySpec
+from curl_cffi.const import CurlHttpVersion, CurlOpt, CurlSslVersion
+from curl_cffi.requests import CookieTypes, HeaderTypes, ProxySpec
 
-from curl_cffi.const import CurlSslVersion, CurlOpt, CurlHttpVersion
-
-BrowserType: TypeAlias = Literal[
+BrowserType = Literal[
     # Edge
     "edge99",
     "edge101",
@@ -105,6 +104,7 @@ class BaseSessionParams(TypedDict, total=False):
     debug: bool
     interface: Optional[str]
     cert: Optional[Union[str, Tuple[str, str]]]
+
 
 # TLS version are in the format of 0xAABB, where AA is major version and BB is minor
 # version. As of today, the major version is always 03.
@@ -253,10 +253,10 @@ TLS_EXTENSION_NAME_MAP = {
     # 64251-64767:"Unassigned
     64768: "ech_outer_extensions",
     # 64769-65036:"Unassigned
-    65037:"encrypted_client_hello",
+    65037: "encrypted_client_hello",
     # 65038-65279:"Unassigned
     # 65280:"Reserved for Private Use
-    65281:"renegotiation_info",
+    65281: "renegotiation_info",
     # 65282-65535:"Reserved for Private Use
 }
 
@@ -282,7 +282,11 @@ def toggle_extension(curl, extension_id: int, enable: bool):
     # compress certificate
     elif extension_id == 27:
         if enable:
-            warnings.warn("Cert compression setting to brotli, you had better specify which to use: zlib/brotli")
+            warnings.warn(
+                "Cert compression setting to brotli, "
+                "you had better specify which to use: zlib/brotli",
+                stacklevel=1,
+            )
             curl.setopt(CurlOpt.SSL_CERT_COMPRESSION, "brotli")
         else:
             curl.setopt(CurlOpt.SSL_CERT_COMPRESSION, "")
@@ -316,4 +320,6 @@ def toggle_extension(curl, extension_id: int, enable: bool):
     elif extension_id == 21:
         pass
     else:
-        raise NotImplementedError(f"This extension({extension_id}) can not be toggled for now, it may be updated later.")
+        raise NotImplementedError(
+            f"This extension({extension_id}) can not be toggled for now, it may be updated later."
+        )

--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -1,49 +1,61 @@
 from dataclasses import dataclass
-from typing import List, Literal, Optional, TypedDict
+from typing import List, Literal, Optional, TypedDict, TypeAlias, Tuple, Union, Callable
 import warnings
-from enum import Enum
 
-from ..const import CurlSslVersion, CurlOpt
+from curl_cffi.requests import HeaderTypes, CookieTypes, ProxySpec
+
+from curl_cffi.const import CurlSslVersion, CurlOpt, CurlHttpVersion
+
+BrowserType: TypeAlias = Literal[
+    # Edge
+    "edge99",
+    "edge101",
+    # Chrome
+    "chrome99",
+    "chrome100",
+    "chrome101",
+    "chrome104",
+    "chrome107",
+    "chrome110",
+    "chrome116",
+    "chrome119",
+    "chrome120",
+    "chrome123",
+    "chrome124",
+    "chrome99_android",
+    # Safari
+    "safari15_3",
+    "safari15_5",
+    "safari17_0",
+    "safari17_2_ios",
+    # alias
+    "chrome",
+    "edge",
+    "safari",
+    "safari_ios",
+    "chrome_android",
+]
+
+DefaultChrome = "chrome124"
+DefaultEdge = "edge101"
+DefaultSafari = "safari17_0"
+DefaultSafariPhone = "safari17_2_ios"
+DefaultChromePhone = "chrome99_android"
 
 
-class BrowserType(str, Enum):
-    edge99 = "edge99"
-    edge101 = "edge101"
-    chrome99 = "chrome99"
-    chrome100 = "chrome100"
-    chrome101 = "chrome101"
-    chrome104 = "chrome104"
-    chrome107 = "chrome107"
-    chrome110 = "chrome110"
-    chrome116 = "chrome116"
-    chrome119 = "chrome119"
-    chrome120 = "chrome120"
-    chrome123 = "chrome123"
-    chrome124 = "chrome124"
-    chrome99_android = "chrome99_android"
-    safari15_3 = "safari15_3"
-    safari15_5 = "safari15_5"
-    safari17_0 = "safari17_0"
-    safari17_2_ios = "safari17_2_ios"
-
-    chrome = "chrome124"
-    safari = "safari17_0"
-    safari_ios = "safari17_2_ios"
-
-    @classmethod
-    def has(cls, item):
-        return item in cls.__members__
-
-    @classmethod
-    def normalize(cls, item):
-        if item == "chrome":  # noqa: SIM116
-            return cls.chrome
-        elif item == "safari":
-            return cls.safari
-        elif item == "safari_ios":
-            return cls.safari_ios
-        else:
-            return item
+def normalize_browser_type(item):
+    if item == "chrome":  # noqa: SIM116
+        return DefaultChrome
+    elif item == "edge":
+        return DefaultEdge
+    elif item == "safari":
+        return DefaultSafari
+    elif item == "safari_ios":
+        return DefaultSafariPhone
+    elif item == "chrome_android":
+        return DefaultChromePhone
+    else:
+        return item
 
 
 @dataclass
@@ -66,6 +78,33 @@ class ExtraFpDict(TypedDict, total=False):
     http2_stream_weight: int
     http2_stream_exclusive: int
 
+
+class BaseSessionParams(TypedDict, total=False):
+    headers: Optional[HeaderTypes]
+    cookies: Optional[CookieTypes]
+    auth: Optional[Tuple[str, str]]
+    proxies: Optional[ProxySpec]
+    proxy: Optional[str]
+    proxy_auth: Optional[Tuple[str, str]]
+    base_url: Optional[str]
+    params: Optional[dict]
+    verify: bool
+    timeout: Union[float, Tuple[float, float]]
+    trust_env: bool
+    allow_redirects: bool
+    max_redirects: int
+    impersonate: Optional[BrowserType]
+    ja3: Optional[str]
+    akamai: Optional[str]
+    extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]]
+    default_headers: bool
+    default_encoding: Union[str, Callable[[bytes], str]]
+    curl_options: Optional[dict]
+    curl_infos: Optional[list]
+    http_version: Optional[CurlHttpVersion]
+    debug: bool
+    interface: Optional[str]
+    cert: Optional[Union[str, Tuple[str, str]]]
 
 # TLS version are in the format of 0xAABB, where AA is major version and BB is minor
 # version. As of today, the major version is always 03.

--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -2,8 +2,8 @@ import warnings
 from dataclasses import dataclass
 from typing import Callable, List, Literal, Optional, Tuple, TypedDict, Union
 
-from curl_cffi.const import CurlHttpVersion, CurlOpt, CurlSslVersion
-from curl_cffi.requests import CookieTypes, HeaderTypes, ProxySpec
+from ..const import CurlHttpVersion, CurlOpt, CurlSslVersion
+from ..requests import CookieTypes, HeaderTypes, ProxySpec
 
 BrowserType = Literal[
     # Edge

--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -35,24 +35,24 @@ BrowserTypeLiteral = Literal[
     "chrome_android",
 ]
 
-DefaultChrome = "chrome124"
-DefaultEdge = "edge101"
-DefaultSafari = "safari17_0"
-DefaultSafariPhone = "safari17_2_ios"
-DefaultChromePhone = "chrome99_android"
+DEFAULT_CHROME = "chrome124"
+DEFAULT_EDGE = "edge101"
+DEFAULT_SAFARI = "safari17_0"
+DEFAULT_SAFARI_IOS = "safari17_2_ios"
+DEFAULT_CHROME_ANDROID = "chrome99_android"
 
 
 def normalize_browser_type(item):
     if item == "chrome":  # noqa: SIM116
-        return DefaultChrome
+        return DEFAULT_CHROME
     elif item == "edge":
-        return DefaultEdge
+        return DEFAULT_EDGE
     elif item == "safari":
-        return DefaultSafari
+        return DEFAULT_SAFARI
     elif item == "safari_ios":
-        return DefaultSafariPhone
+        return DEFAULT_SAFARI_IOS
     elif item == "chrome_android":
-        return DefaultChromePhone
+        return DEFAULT_CHROME_ANDROID
     else:
         return item
 

--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -1,9 +1,8 @@
 import warnings
 from dataclasses import dataclass
-from typing import Callable, List, Literal, Optional, Tuple, TypedDict, Union
+from typing import List, Literal, Optional, TypedDict
 
-from ..const import CurlHttpVersion, CurlOpt, CurlSslVersion
-from ..requests import CookieTypes, HeaderTypes, ProxySpec
+from ..const import CurlOpt, CurlSslVersion
 
 BrowserType = Literal[
     # Edge
@@ -76,34 +75,6 @@ class ExtraFpDict(TypedDict, total=False):
     tls_signature_algorithms: Optional[List[str]]
     http2_stream_weight: int
     http2_stream_exclusive: int
-
-
-class BaseSessionParams(TypedDict, total=False):
-    headers: Optional[HeaderTypes]
-    cookies: Optional[CookieTypes]
-    auth: Optional[Tuple[str, str]]
-    proxies: Optional[ProxySpec]
-    proxy: Optional[str]
-    proxy_auth: Optional[Tuple[str, str]]
-    base_url: Optional[str]
-    params: Optional[dict]
-    verify: bool
-    timeout: Union[float, Tuple[float, float]]
-    trust_env: bool
-    allow_redirects: bool
-    max_redirects: int
-    impersonate: Optional[BrowserType]
-    ja3: Optional[str]
-    akamai: Optional[str]
-    extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]]
-    default_headers: bool
-    default_encoding: Union[str, Callable[[bytes], str]]
-    curl_options: Optional[dict]
-    curl_infos: Optional[list]
-    http_version: Optional[CurlHttpVersion]
-    debug: bool
-    interface: Optional[str]
-    cert: Optional[Union[str, Tuple[str, str]]]
 
 
 # TLS version are in the format of 0xAABB, where AA is major version and BB is minor

--- a/curl_cffi/requests/impersonate.py
+++ b/curl_cffi/requests/impersonate.py
@@ -1,10 +1,11 @@
 import warnings
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Literal, Optional, TypedDict
 
 from ..const import CurlOpt, CurlSslVersion
 
-BrowserType = Literal[
+BrowserTypeLiteral = Literal[
     # Edge
     "edge99",
     "edge101",
@@ -54,6 +55,27 @@ def normalize_browser_type(item):
         return DefaultChromePhone
     else:
         return item
+
+
+class BrowserType(str, Enum):  # todo: remove in version 1.x
+    edge99 = "edge99"
+    edge101 = "edge101"
+    chrome99 = "chrome99"
+    chrome100 = "chrome100"
+    chrome101 = "chrome101"
+    chrome104 = "chrome104"
+    chrome107 = "chrome107"
+    chrome110 = "chrome110"
+    chrome116 = "chrome116"
+    chrome119 = "chrome119"
+    chrome120 = "chrome120"
+    chrome123 = "chrome123"
+    chrome124 = "chrome124"
+    chrome99_android = "chrome99_android"
+    safari15_3 = "safari15_3"
+    safari15_5 = "safari15_5"
+    safari17_0 = "safari17_0"
+    safari17_2_ios = "safari17_2_ios"
 
 
 @dataclass

--- a/curl_cffi/requests/models.py
+++ b/curl_cffi/requests/models.py
@@ -153,10 +153,11 @@ class Response:
             if pending is not None:
                 chunk = pending + chunk
             lines = chunk.split(delimiter) if delimiter else chunk.splitlines()
-            if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
-                pending = lines.pop()
-            else:
-                pending = None
+            pending = (
+                lines.pop()
+                if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]
+                else None
+            )
 
             yield from lines
 
@@ -214,10 +215,11 @@ class Response:
             if pending is not None:
                 chunk = pending + chunk
             lines = chunk.split(delimiter) if delimiter else chunk.splitlines()
-            if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]:
-                pending = lines.pop()
-            else:
-                pending = None
+            pending = (
+                lines.pop()
+                if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]
+                else None
+            )
 
             for line in lines:
                 yield line

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -35,7 +35,7 @@ from .impersonate import (
     TLS_CIPHER_NAME_MAP,
     TLS_EC_CURVES_MAP,
     TLS_VERSION_MAP,
-    BrowserType,
+    BrowserTypeLiteral,
     ExtraFingerprints,
     ExtraFpDict,
     normalize_browser_type,
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
         trust_env: bool
         allow_redirects: bool
         max_redirects: int
-        impersonate: Optional[BrowserType]
+        impersonate: Optional[BrowserTypeLiteral]
         ja3: Optional[str]
         akamai: Optional[str]
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]]
@@ -207,7 +207,7 @@ class BaseSession:
         trust_env: bool = True,
         allow_redirects: bool = True,
         max_redirects: int = 30,
-        impersonate: Optional[BrowserType] = None,
+        impersonate: Optional[BrowserTypeLiteral] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
@@ -364,7 +364,7 @@ class BaseSession:
         referer: Optional[str] = None,
         accept_encoding: Optional[str] = "gzip, deflate, br, zstd",
         content_callback: Optional[Callable] = None,
-        impersonate: Optional[BrowserType] = None,
+        impersonate: Optional[BrowserTypeLiteral] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
@@ -906,7 +906,7 @@ class Session(BaseSession):
         referer: Optional[str] = None,
         accept_encoding: Optional[str] = "gzip, deflate, br",
         content_callback: Optional[Callable] = None,
-        impersonate: Optional[BrowserType] = None,
+        impersonate: Optional[BrowserTypeLiteral] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
@@ -1198,7 +1198,7 @@ class AsyncSession(BaseSession):
         referer: Optional[str] = None,
         accept_encoding: Optional[str] = "gzip, deflate, br",
         content_callback: Optional[Callable] = None,
-        impersonate: Optional[BrowserType] = None,
+        impersonate: Optional[BrowserTypeLiteral] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -20,7 +20,7 @@ from typing import (
     Tuple,
     TypedDict,
     Union,
-    cast,
+    cast, Unpack,
 )
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urljoin, urlparse
 
@@ -37,7 +37,7 @@ from .impersonate import (
     BrowserType,
     TLS_VERSION_MAP,
     TLS_CIPHER_NAME_MAP,
-    TLS_EC_CURVES_MAP
+    TLS_EC_CURVES_MAP, normalize_browser_type, BaseSessionParams
 )
 from .models import Request, Response
 from .websockets import WebSocket
@@ -177,7 +177,7 @@ class BaseSession:
         trust_env: bool = True,
         allow_redirects: bool = True,
         max_redirects: int = 30,
-        impersonate: Optional[Union[str, BrowserType]] = None,
+        impersonate: Optional[BrowserType] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
@@ -334,7 +334,7 @@ class BaseSession:
         referer: Optional[str] = None,
         accept_encoding: Optional[str] = "gzip, deflate, br, zstd",
         content_callback: Optional[Callable] = None,
-        impersonate: Optional[Union[str, BrowserType]] = None,
+        impersonate: Optional[BrowserType] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
@@ -577,7 +577,7 @@ class BaseSession:
         impersonate = impersonate or self.impersonate
         default_headers = self.default_headers if default_headers is None else default_headers
         if impersonate:
-            impersonate = BrowserType.normalize(impersonate)
+            impersonate = normalize_browser_type(impersonate)
             ret = c.impersonate(impersonate, default_headers=default_headers)
             if ret != 0:
                 raise RequestsError(f"Impersonating {impersonate} is not supported")
@@ -716,7 +716,7 @@ class Session(BaseSession):
         curl: Optional[Curl] = None,
         thread: Optional[ThreadType] = None,
         use_thread_local_curl: bool = True,
-        **kwargs,
+        **kwargs: Unpack[BaseSessionParams],
     ):
         """
         Parameters set in the init method will be override by the same parameter in request method.
@@ -875,7 +875,7 @@ class Session(BaseSession):
         referer: Optional[str] = None,
         accept_encoding: Optional[str] = "gzip, deflate, br",
         content_callback: Optional[Callable] = None,
-        impersonate: Optional[Union[str, BrowserType]] = None,
+        impersonate: Optional[BrowserType] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,
@@ -1013,7 +1013,7 @@ class AsyncSession(BaseSession):
         loop=None,
         async_curl: Optional[AsyncCurl] = None,
         max_clients: int = 10,
-        **kwargs,
+        **kwargs: Unpack[BaseSessionParams],
     ):
         """
         Parameters set in the init method will be override by the same parameter in request method.
@@ -1167,7 +1167,7 @@ class AsyncSession(BaseSession):
         referer: Optional[str] = None,
         accept_encoding: Optional[str] = "gzip, deflate, br",
         content_callback: Optional[Callable] = None,
-        impersonate: Optional[Union[str, BrowserType]] = None,
+        impersonate: Optional[BrowserType] = None,
         ja3: Optional[str] = None,
         akamai: Optional[str] = None,
         extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]] = None,

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -24,6 +24,8 @@ from typing import (
 )
 from urllib.parse import ParseResult, parse_qsl, unquote, urlencode, urljoin, urlparse
 
+from typing_extensions import Unpack
+
 from .. import AsyncCurl, Curl, CurlError, CurlHttpVersion, CurlInfo, CurlOpt, CurlSslVersion
 from ..curl import CURL_WRITEFUNC_ERROR, CurlMime
 from .cookies import Cookies, CookieTypes, CurlMorsel
@@ -33,7 +35,6 @@ from .impersonate import (
     TLS_CIPHER_NAME_MAP,
     TLS_EC_CURVES_MAP,
     TLS_VERSION_MAP,
-    BaseSessionParams,
     BrowserType,
     ExtraFingerprints,
     ExtraFpDict,
@@ -50,7 +51,6 @@ with suppress(ImportError):
     import eventlet.tpool
 
 if TYPE_CHECKING:
-    from typing_extensions import Unpack
 
     class ProxySpec(TypedDict, total=False):
         all: str
@@ -59,8 +59,36 @@ if TYPE_CHECKING:
         ws: str
         wss: str
 
+    class BaseSessionParams(TypedDict, total=False):
+        headers: Optional[HeaderTypes]
+        cookies: Optional[CookieTypes]
+        auth: Optional[Tuple[str, str]]
+        proxies: Optional[ProxySpec]
+        proxy: Optional[str]
+        proxy_auth: Optional[Tuple[str, str]]
+        base_url: Optional[str]
+        params: Optional[dict]
+        verify: bool
+        timeout: Union[float, Tuple[float, float]]
+        trust_env: bool
+        allow_redirects: bool
+        max_redirects: int
+        impersonate: Optional[BrowserType]
+        ja3: Optional[str]
+        akamai: Optional[str]
+        extra_fp: Optional[Union[ExtraFingerprints, ExtraFpDict]]
+        default_headers: bool
+        default_encoding: Union[str, Callable[[bytes], str]]
+        curl_options: Optional[dict]
+        curl_infos: Optional[list]
+        http_version: Optional[CurlHttpVersion]
+        debug: bool
+        interface: Optional[str]
+        cert: Optional[Union[str, Tuple[str, str]]]
+
 else:
     ProxySpec = Dict[str, str]
+    BaseSessionParams = TypedDict
 
 ThreadType = Literal["eventlet", "gevent"]
 

--- a/curl_cffi/requests/session.py
+++ b/curl_cffi/requests/session.py
@@ -35,6 +35,7 @@ from .impersonate import (
     TLS_CIPHER_NAME_MAP,
     TLS_EC_CURVES_MAP,
     TLS_VERSION_MAP,
+    BrowserType,  # noqa: F401
     BrowserTypeLiteral,
     ExtraFingerprints,
     ExtraFpDict,

--- a/examples/impersonate.py
+++ b/examples/impersonate.py
@@ -37,12 +37,9 @@ extra_fp = {
     # tls_signature_algorithms: Optional[List[str]] = None
     # http2_stream_weight: int = 256
     # http2_stream_exclusive: int = 1
-
     # See requests/impersonate.py and tests/unittest/test_impersonate.py for more examples
 }
 
 
-r = requests.get(
-    url, ja3=okhttp4_android10_ja3, akamai=okhttp4_android10_akamai, extra_fp=extra_fp
-)
+r = requests.get(url, ja3=okhttp4_android10_ja3, akamai=okhttp4_android10_akamai, extra_fp=extra_fp)
 print(r.json())

--- a/tests/integration/test_fingerprints.py
+++ b/tests/integration/test_fingerprints.py
@@ -22,7 +22,7 @@ def test_impersonate():
 
 
 def test_impersonate_edge():
-    r = requests.get(JA3_URL, impersonate=requests.BrowserType.edge101)
+    r = requests.get(JA3_URL, impersonate="edge101")
     assert r.json()["ja3_hash"] == EDGE_JA3_HASH
 
 

--- a/tests/unittest/test_impersonate.py
+++ b/tests/unittest/test_impersonate.py
@@ -6,24 +6,16 @@ from curl_cffi.const import CurlHttpVersion, CurlSslVersion
 
 def test_impersonate_with_version(server):
     # the test server does not understand http/2
-    r = requests.get(
-        str(server.url), impersonate="chrome120", http_version=CurlHttpVersion.V1_1
-    )
+    r = requests.get(str(server.url), impersonate="chrome120", http_version=CurlHttpVersion.V1_1)
     assert r.status_code == 200
-    r = requests.get(
-        str(server.url), impersonate="safari17_0", http_version=CurlHttpVersion.V1_1
-    )
+    r = requests.get(str(server.url), impersonate="safari17_0", http_version=CurlHttpVersion.V1_1)
     assert r.status_code == 200
 
 
 def test_impersonate_without_version(server):
-    r = requests.get(
-        str(server.url), impersonate="chrome", http_version=CurlHttpVersion.V1_1
-    )
+    r = requests.get(str(server.url), impersonate="chrome", http_version=CurlHttpVersion.V1_1)
     assert r.status_code == 200
-    r = requests.get(
-        str(server.url), impersonate="safari_ios", http_version=CurlHttpVersion.V1_1
-    )
+    r = requests.get(str(server.url), impersonate="safari_ios", http_version=CurlHttpVersion.V1_1)
     assert r.status_code == 200
 
 
@@ -47,7 +39,10 @@ def test_costomized_no_impersonate_coexist(server):
 
 def test_customized_ja3_chrome126():
     url = "https://tls.browserleaks.com/json"
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     assert r["ja3_text"] == ja3
 
@@ -55,7 +50,10 @@ def test_customized_ja3_chrome126():
 @pytest.mark.skip(reason="not working")
 def test_customized_ja3_tls_version():
     url = "https://tls.browserleaks.com/json"
-    ja3 = "770,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-29-23-24,0"
+    ja3 = (
+        "770,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     tls_version, _, _, _, _ = r["ja3_text"].split(",")
     assert tls_version == "770"
@@ -63,7 +61,10 @@ def test_customized_ja3_tls_version():
 
 def test_customized_ja3_ciphers():
     url = "https://tls.browserleaks.com/json"
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171,0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171,"
+        "0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     _, ciphers, _, _, _ = r["ja3_text"].split(",")
     assert ciphers == "4865-4866-4867-49195-49199-49196-49200-52393-52392-49171"
@@ -72,23 +73,35 @@ def test_customized_ja3_ciphers():
 # TODO change to parameterized test
 def test_customized_ja3_extensions():
     url = "https://tls.browserleaks.com/json"
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     _, _, extensions, _, _ = r["ja3_text"].split(",")
     assert extensions == "65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51"
 
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     _, _, extensions, _, _ = r["ja3_text"].split(",")
     assert extensions == "65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51"
 
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,65281-0-11-23-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "65281-0-11-23-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     _, _, extensions, _, _ = r["ja3_text"].split(",")
     assert extensions == "65281-0-11-23-27-16-17513-10-35-43-45-13-51"
 
     # removed enable session_ticket()
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,65281-0-11-23-5-18-27-16-17513-10-43-45-13-51,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "65281-0-11-23-5-18-27-16-17513-10-43-45-13-51,25497-29-23-24,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     _, _, extensions, _, _ = r["ja3_text"].split(",")
     assert extensions == "65281-0-11-23-5-18-27-16-17513-10-43-45-13-51"
@@ -96,7 +109,10 @@ def test_customized_ja3_extensions():
 
 def test_customized_ja3_curves():
     url = "https://tls.browserleaks.com/json"
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-24-23-29,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "0-65037-27-51-13-43-5-18-17513-65281-23-10-45-35-11-16,25497-24-23-29,0"
+    )
     r = requests.get(url, ja3=ja3).json()
     _, _, _, curves, _ = r["ja3_text"].split(",")
     assert curves == "25497-24-23-29"
@@ -160,13 +176,18 @@ def test_customized_extra_fp_grease():
 
 def test_customized_extra_fp_permute():
     url = "https://tls.browserleaks.com/json"
-    ja3 = "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    ja3 = (
+        "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,"
+        "65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51,25497-29-23-24,0"
+    )
 
     r = requests.get(url, ja3=ja3).json()
     _, _, extensions, _, _ = r["ja3_text"].split(",")
     assert extensions == "65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51"
 
-    r = requests.get(url, ja3=ja3, extra_fp=requests.ExtraFingerprints(tls_permute_extensions=True)).json()
+    r = requests.get(
+        url, ja3=ja3, extra_fp=requests.ExtraFingerprints(tls_permute_extensions=True)
+    ).json()
     _, _, extensions, _, _ = r["ja3_text"].split(",")
     assert extensions != "65037-65281-0-11-23-5-18-27-16-17513-10-35-43-45-13-51"
 

--- a/tests/unittest/test_impersonate.py
+++ b/tests/unittest/test_impersonate.py
@@ -21,7 +21,7 @@ def test_impersonate_without_version(server):
 
 def test_impersonate_non_exist(server):
     with pytest.raises(requests.RequestsError, match="Impersonating"):
-        requests.get(str(server.url), impersonate="edge")
+        requests.get(str(server.url), impersonate="edge2131")
     with pytest.raises(requests.RequestsError, match="Impersonating"):
         requests.get(str(server.url), impersonate="chrome2952")
 

--- a/tests/unittest/test_requests.py
+++ b/tests/unittest/test_requests.py
@@ -156,7 +156,9 @@ def test_headers(server):
 
 
 def test_empty_header_included(server):
-    r = requests.get(str(server.url.copy_with(path="/echo_headers")), headers={"foo": "bar", "xxx": ""})
+    r = requests.get(
+        str(server.url.copy_with(path="/echo_headers")), headers={"foo": "bar", "xxx": ""}
+    )
     headers = r.json()
     assert headers["Foo"][0] == "bar"
     assert headers["Xxx"][0] == ""
@@ -762,4 +764,3 @@ def test_response_ip(server):
 
     assert r.primary_ip == "127.0.0.1"
     assert r.local_ip == "127.0.0.1"
-

--- a/tests/unittest/test_smoke.py
+++ b/tests/unittest/test_smoke.py
@@ -15,7 +15,7 @@ def test_without_impersonate():
 
 def test_with_impersonate():
     for url in URLS:
-        r = requests.get(url, impersonate=requests.BrowserType.chrome)
+        r = requests.get(url, impersonate="chrome")
         assert r.status_code == 200
 
 


### PR DESCRIPTION
Hints for enhancing `impersonate`.

For method impersonate:

![image](https://github.com/user-attachments/assets/9bcdb8fd-7594-4df1-a7f6-2abca09e70e7)

For session impersonate:

![image](https://github.com/user-attachments/assets/7f26422c-bd49-417e-9134-a5501cf9571a)

For session kwargs:

![image](https://github.com/user-attachments/assets/317247e4-f757-49a7-9b68-64ae9c38135d)

